### PR TITLE
Multi-target .NET Framework 4.6.2

### DIFF
--- a/SqlServer.Rules/MessageFormatter.cs
+++ b/SqlServer.Rules/MessageFormatter.cs
@@ -1,3 +1,7 @@
+#if NETFRAMEWORK
+using SqlServer.Dac;
+#endif
+
 namespace SqlServer.Rules
 {
     internal static class MessageFormatter

--- a/SqlServer.Rules/Misc.cs
+++ b/SqlServer.Rules/Misc.cs
@@ -59,5 +59,54 @@ namespace SqlServer.Dac
 
             return Comparer.Equals(value1, value2);
         }
+
+#if NETFRAMEWORK
+        public static bool Contains(this string str, char value, StringComparison comparison)
+        {
+            return str.IndexOf(new string(value, 1), comparison) >= 0;
+        }
+
+        public static bool Contains(this string str, string value, StringComparison comparison)
+        {
+            return str.IndexOf(value, comparison) >= 0;
+        }
+
+        public static bool StartsWith(this string str, char value)
+        {
+            return str.Length > 0 && str[0] == value;
+        }
+
+        public static string Replace(this string str, string find, string replace, StringComparison comparison)
+        {
+            var index = str.IndexOf(find, comparison);
+
+            while (index >= 0)
+            {
+                str = str.Remove(index, find.Length).Insert(index, replace);
+                index = str.IndexOf(find, index + replace.Length, comparison);
+            }
+
+            return str;
+        }
+
+        public static int GetHashCode(this string str, StringComparison comparison)
+        {
+            return GetComparer(comparison).GetHashCode(str);
+        }
+
+        private static StringComparer GetComparer(this StringComparison comparison)
+        {
+            return comparison switch
+            {
+                StringComparison.CurrentCulture => StringComparer.CurrentCulture,
+                StringComparison.CurrentCultureIgnoreCase => StringComparer.CurrentCultureIgnoreCase,
+                StringComparison.InvariantCulture => StringComparer.InvariantCulture,
+                StringComparison.InvariantCultureIgnoreCase => StringComparer.InvariantCultureIgnoreCase,
+                StringComparison.Ordinal => StringComparer.Ordinal,
+                StringComparison.OrdinalIgnoreCase => StringComparer.OrdinalIgnoreCase,
+                _ => throw new ArgumentOutOfRangeException(nameof(comparison), comparison, null),
+            };
+        }
+#endif
     }
 }

--- a/SqlServer.Rules/SqlServer.Rules.csproj
+++ b/SqlServer.Rules/SqlServer.Rules.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <PackageId>ErikEJ.DacFX.SqlServer.Rules</PackageId>
     <Version>1.2.1</Version>
@@ -26,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="162.5.57" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.6.0" Condition=" '$(TargetFramework)' == 'net462' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/SqlServer.TSQLSmells/Processors/CreateTableProcessor.cs
+++ b/SqlServer.TSQLSmells/Processors/CreateTableProcessor.cs
@@ -13,8 +13,13 @@ namespace TSQLSmellSCA
 
         public void ProcessCreateTable(CreateTableStatement tblStmt)
         {
+#if NETSTANDARD
             var isTemp = tblStmt.SchemaObjectName.BaseIdentifier.Value.StartsWith('#') ||
                           tblStmt.SchemaObjectName.BaseIdentifier.Value.StartsWith('@');
+#else
+            var isTemp = tblStmt.SchemaObjectName.BaseIdentifier.Value.StartsWith("#", System.StringComparison.Ordinal) ||
+                          tblStmt.SchemaObjectName.BaseIdentifier.Value.StartsWith("@", System.StringComparison.Ordinal);
+#endif
 
             if (tblStmt.SchemaObjectName.SchemaIdentifier == null &&
                 !isTemp)

--- a/SqlServer.TSQLSmells/TSQLSmellSCA.csproj
+++ b/SqlServer.TSQLSmells/TSQLSmellSCA.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageId>ErikEJ.DacFX.TSQLSmellSCA</PackageId>
     <Version>1.2.1</Version>
@@ -45,5 +46,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="162.5.57" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.6.0" Condition=" '$(TargetFramework)' == 'net462' " />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I was hitting the same error as #67 due to computed columns when using version 1.0.0 of the package as described [on your blog](https://erikej.github.io/dacfx/codeanalysis/sqlserver/2024/04/02/dacfx-codeanalysis.html) for compatibility with sqlproj.

This change let me build the latest version for .NET Framework 4.6.2 so I can use the fix in #68 in my project by adding a conditional set of extension methods for compatibility with .NET Standard 2.1, hopefully this will allow anyone using the sqlproj format to use the most recent version of these analyzers.