### PR TITLE
Add ability to analyze script string - but must be DDL, cannot be pure DML

### DIFF
--- a/SqlServer.Rules.sln
+++ b/SqlServer.Rules.sln
@@ -210,6 +210,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ErikEJ.DacFX.TSQLAnalyzer",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chinook", "sqlprojects\Chinook\Chinook.csproj", "{EA8DA413-F1FC-EC5A-9755-65C34D12680C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TSQLAnalyzer.Tests", "test\TSQLAnalyzer.Tests\TSQLAnalyzer.Tests.csproj", "{FBDB31C2-D200-E4F6-4DF1-F3DB1211118F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -260,6 +262,10 @@ Global
 		{F5B22019-FE37-3503-DDA4-E116C7BFB2F7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EA8DA413-F1FC-EC5A-9755-65C34D12680C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EA8DA413-F1FC-EC5A-9755-65C34D12680C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBDB31C2-D200-E4F6-4DF1-F3DB1211118F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBDB31C2-D200-E4F6-4DF1-F3DB1211118F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBDB31C2-D200-E4F6-4DF1-F3DB1211118F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBDB31C2-D200-E4F6-4DF1-F3DB1211118F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -283,6 +289,7 @@ Global
 		{E9D0C71E-D3A0-4D87-8E82-7DDBB42F7F07} = {AB713AEF-EE54-487A-AE70-8DD69973A2F9}
 		{F5B22019-FE37-3503-DDA4-E116C7BFB2F7} = {AB713AEF-EE54-487A-AE70-8DD69973A2F9}
 		{EA8DA413-F1FC-EC5A-9755-65C34D12680C} = {4EB38410-F29F-4143-A19E-BE8AE8FEED26}
+		{FBDB31C2-D200-E4F6-4DF1-F3DB1211118F} = {7FF3EC52-EC83-44FC-9BDA-463CDC01CB14}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {67B59E89-8C35-419D-A49B-9C2C19584900}

--- a/test/TSQLAnalyzer.Tests/ScriptAnalyzerTests.cs
+++ b/test/TSQLAnalyzer.Tests/ScriptAnalyzerTests.cs
@@ -1,0 +1,33 @@
+using ErikEJ.DacFX.TSQLAnalyzer;
+using Microsoft.SqlServer.Dac.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SqlServer.Rules.Tests.Docs;
+
+[TestClass]
+[TestCategory("Analyzer")]
+public class ScriptAnalyzerTests
+{
+    [TestMethod]
+    public void CanCallApiWithScriptString()
+    {
+        // Arrange
+        // Notice that script must be an object creation script.
+        var script = @"CREATE PROCEDURE dbo.TestProc AS SELECT * FROM sys.objects";
+
+        var options = new AnalyzerOptions
+        {
+            Script = script,
+            SqlVersion = SqlServerVersion.Sql160,
+        };
+        var analyzer = new AnalyzerFactory(options);
+
+        // Act
+        var analysis = analyzer.Analyze();
+
+        // Assert
+        Assert.IsNotNull(analysis);
+        Assert.IsNotNull(analysis.Result);
+        Assert.IsTrue(analysis.Result.Problems.Count > 0, "Expected problems but found none.");
+    }
+}

--- a/test/TSQLAnalyzer.Tests/TSQLAnalyzer.Tests.csproj
+++ b/test/TSQLAnalyzer.Tests/TSQLAnalyzer.Tests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>string</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\ErikEJ.DacFX.TSQLAnalyzer\ErikEJ.DacFX.TSQLAnalyzer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/ErikEJ.DacFX.TSQLAnalyzer/AnalyzerOptions.cs
+++ b/tools/ErikEJ.DacFX.TSQLAnalyzer/AnalyzerOptions.cs
@@ -6,7 +6,7 @@ namespace ErikEJ.DacFX.TSQLAnalyzer;
 public class AnalyzerOptions
 {
     /// <summary>
-    /// Used to specify the scripts to analyze, can be a single file or a directory or a wildcard. Required if connection string is not set.
+    /// Used to specify the scripts to analyze, can be a single file or a directory or a wildcard. Required if connection string or script is not set.
     /// </summary>
 #pragma warning disable CA2227 // Collection properties should be read only
 #pragma warning disable CA1002 // Do not expose generic lists
@@ -19,10 +19,15 @@ public class AnalyzerOptions
 #pragma warning restore CA1002 // Do not expose generic lists
 
     /// <summary>
-    /// Used to specify the connection string to a SQL Server database. Required if scripts is not set.
+    /// Used to specify the connection string to a SQL Server database. Required if scripts or script is not set.
     /// </summary>
     public SqlConnectionStringBuilder? ConnectionString { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
+
+    /// <summary>
+    /// Used to specify the SQL script body to analyze. Required if connection string or scripts is not set.
+    /// </summary>
+    public string? Script { get; set; }
 
     /// <summary>
     /// Used to specify a rules expression similar to 'Rules:-SqlServer.Rules.SRD0010;+!SqlServer.Rules.SRN0005'. Optional.

--- a/tools/SqlAnalyzerCli/testfiles/simple.sql
+++ b/tools/SqlAnalyzerCli/testfiles/simple.sql
@@ -1,0 +1,1 @@
+CREATE PROCEDURE dbo.TestProc AS SELECT * FROM sys.objects

--- a/tools/SqlAnalyzerCli/testfiles/smoketest.cmd
+++ b/tools/SqlAnalyzerCli/testfiles/smoketest.cmd
@@ -4,6 +4,9 @@ pause
 ..\bin\Debug\net8.0\ErikEJ.TSQLAnalyzerCli.exe -i sproc.sql
 pause
 
+..\bin\Debug\net8.0\ErikEJ.TSQLAnalyzerCli.exe -i simple.sql
+pause
+
 ..\bin\Debug\net8.0\ErikEJ.TSQLAnalyzerCli.exe -i sproc.sql -o output.xml
 pause
 


### PR DESCRIPTION
fixes #210

@simoncropp This is using DacFX, so the script must be a DDL script, not DML - so for a SELECT/INSERT/UPDATE/DELETE statement, the caller could prefix with "CREATE PROCEDURE dummy AS " 
