### PR TITLE
Add option to omit XML declaration in serialization

### DIFF
--- a/tools/SqlServer.Rules.Report/ReportFactory.cs
+++ b/tools/SqlServer.Rules.Report/ReportFactory.cs
@@ -200,7 +200,7 @@ public class ReportFactory
         {            
             Indent = true,
             IndentChars = "\t",
-            OmitXMLDeclaration = true,
+            OmitXmlDeclaration = true,
         };
         using (var writer = XmlWriter.Create(outputPath, xmlSettings))
         {


### PR DESCRIPTION
Added an option to omit the XML declaration when serializing reports.