### PR TITLE
Remove TSQLSmellSCA pack/sign; update TestModel default

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,8 +44,6 @@ jobs:
       - name: Sign .dll files
         if: github.ref == 'refs/heads/master' && github.repository_owner == 'erikej' && github.event_name == 'workflow_dispatch'
         run: sign code artifact-signing `
-          ./src/SqlServer.TSQLSmells/bin/Release/net472/TSQLSmellSCA.NetFx.dll `
-          ./src/SqlServer.TSQLSmells/bin/Release/netstandard2.1/TSQLSmellSCA.dll `
           ./src/SqlServer.Rules/bin/Release/net472/SqlServer.Rules.NetFx.dll `
           ./src/SqlServer.Rules/bin/Release/netstandard2.1/SqlServer.Rules.dll `
           --artifact-signing-account ErikEJ `
@@ -55,9 +53,6 @@ jobs:
 
       - name: Pack
         run: dotnet pack ./src/SqlServer.Rules/SqlServer.Rules.csproj --no-build --configuration Release
-
-      - name: Pack
-        run: dotnet pack ./src/SqlServer.TSQLSmells/TSQLSmellSCA.csproj --no-build --configuration Release
 
       - name: Publish artifacts
         if: github.ref == 'refs/heads/master' && github.repository_owner == 'erikej' && (github.event_name == 'push' ||  github.event_name == 'workflow_dispatch')

--- a/test/TestHelpers/TestModel.cs
+++ b/test/TestHelpers/TestModel.cs
@@ -14,7 +14,7 @@ public class TestModel
 
     private string Prefix { get; set; }
 
-    public TestModel(string prefix = "Smells.")
+    public TestModel(string prefix = TestConstants.SqlServerRules)
     {
         Model = new TSqlModel(SqlServerVersion.Sql150, null);
         Prefix = prefix;


### PR DESCRIPTION
Removed TSQLSmellSCA DLL signing and packing from publish.yml, so only SqlServer.Rules is packed. Updated TestModel to use TestConstants.SqlServerRules as the default prefix instead of "Smells.".