### PR TITLE
Clarify MsBuild.Sdk.SqlProj property names in rules

### DIFF
--- a/docs/Design/SRD0700.md
+++ b/docs/Design/SRD0700.md
@@ -18,7 +18,7 @@
   
 ## Description
   
-Set '<PageVerify>CHECKSUM</PageVerify>' in the project file to enable PAGE_VERIFY = CHECKSUM. (Use '<PageVerifyMode>Checksum</PageVerifyMode>' for MsBuild.Sdk.SqlProj projects.)
+Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM. (Use `<PageVerifyMode>Checksum</PageVerifyMode>` for MsBuild.Sdk.SqlProj projects.)
   
 ## Summary
   

--- a/docs/Design/SRD0700.md
+++ b/docs/Design/SRD0700.md
@@ -18,7 +18,7 @@
   
 ## Description
   
-Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM. (Use `<PageVerifyMode>Checksum</PageVerifyMode>` for MsBuild.Sdk.SqlProj projects.)
+Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM. (Use `<PageVerifyMode>Checksum</PageVerifyMode>` for MSBuild.Sdk.SqlProj projects.)
   
 ## Summary
   

--- a/docs/Design/SRD0700.md
+++ b/docs/Design/SRD0700.md
@@ -18,7 +18,7 @@
   
 ## Description
   
-Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM.
+Set '<PageVerify>CHECKSUM</PageVerify>' in the project file to enable PAGE_VERIFY = CHECKSUM. (Use '<PageVerifyMode>Checksum</PageVerifyMode>' for MsBuild.Sdk.SqlProj projects.)
   
 ## Summary
   

--- a/docs/Design/SRD0701.md
+++ b/docs/Design/SRD0701.md
@@ -18,7 +18,7 @@
   
 ## Description
   
-Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store.
+Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store. (Use `<QueryStoreDesiredState>ReadWrite</QueryStoreDesiredState>` for MsBuild.Sdk.SqlProj projects.)
   
 ## Summary
   

--- a/docs/Design/SRD0701.md
+++ b/docs/Design/SRD0701.md
@@ -18,7 +18,7 @@
   
 ## Description
   
-Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store. (Use `<QueryStoreDesiredState>ReadWrite</QueryStoreDesiredState>` for MsBuild.Sdk.SqlProj projects.)
+Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store. (Use `<QueryStoreDesiredState>ReadWrite</QueryStoreDesiredState>` for MSBuild.Sdk.SqlProj projects.)
   
 ## Summary
   

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -88,8 +88,8 @@
 | [SRD0094](Design/SRD0094.md) | Avoid named foreign keys on temporary tables | Yes | Foreign key constraints on temp tables should not be named. |   |
 | [SRD0095](Design/SRD0095.md) | Named check constraints on temp tables | Yes | Check constraints on temp tables should not be named. | Yes |
 | [SRD0096](Design/SRD0096.md) | Potential SQL injection issue |   | Potential SQL injection issue. | Yes |
-| [SRD0700](Design/SRD0700.md) | Database PAGE_VERIFY option is not CHECKSUM |   | Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM. (Use `<PageVerifyMode>Checksum</PageVerifyMode>` for MsBuild.Sdk.SqlProj projects.) |   |
-| [SRD0701](Design/SRD0701.md) | Database QUERY_STORE option is not READ_WRITE |   | Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store. (Use `<QueryStoreDesiredState>ReadWrite</QueryStoreDesiredState>` for MsBuild.Sdk.SqlProj projects.) |   |
+| [SRD0700](Design/SRD0700.md) | Database PAGE_VERIFY option is not CHECKSUM |   | Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM. (Use `<PageVerifyMode>Checksum</PageVerifyMode>` for MSBuild.Sdk.SqlProj projects.) |   |
+| [SRD0701](Design/SRD0701.md) | Database QUERY_STORE option is not READ_WRITE |   | Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store. (Use `<QueryStoreDesiredState>ReadWrite</QueryStoreDesiredState>` for MSBuild.Sdk.SqlProj projects.) |   |
 | [SRD0703](Design/SRD0703.md) | Database QUERY_STORE_CAPTURE_MODE option is not AUTO |   | Set `<QueryStoreCaptureMode>AUTO</QueryStoreCaptureMode>` in the project file to enable QUERY_STORE_CAPTURE_MODE = AUTO. |   |
 | [SRD0704](Design/SRD0704.md) | Database TARGET_RECOVERY_TIME option is not set |   | Set `<TargetRecoveryTimePeriod>60</TargetRecoveryTimePeriod>` in the project file to enable TARGET_RECOVERY_TIME. |   |
 | [SRD0705](Design/SRD0705.md) | Database AUTO_CLOSE option is not OFF |   | Set `<AutoClose>False</AutoClose>` in the project file to disable AUTO_CLOSE. |   |

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -88,8 +88,8 @@
 | [SRD0094](Design/SRD0094.md) | Avoid named foreign keys on temporary tables | Yes | Foreign key constraints on temp tables should not be named. |   |
 | [SRD0095](Design/SRD0095.md) | Named check constraints on temp tables | Yes | Check constraints on temp tables should not be named. | Yes |
 | [SRD0096](Design/SRD0096.md) | Potential SQL injection issue |   | Potential SQL injection issue. | Yes |
-| [SRD0700](Design/SRD0700.md) | Database PAGE_VERIFY option is not CHECKSUM |   | Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM. |   |
-| [SRD0701](Design/SRD0701.md) | Database QUERY_STORE option is not READ_WRITE |   | Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store. |   |
+| [SRD0700](Design/SRD0700.md) | Database PAGE_VERIFY option is not CHECKSUM |   | Set '<PageVerify>CHECKSUM</PageVerify>' in the project file to enable PAGE_VERIFY = CHECKSUM. (Use '<PageVerifyMode>Checksum</PageVerifyMode>' for MsBuild.Sdk.SqlProj projects.) |   |
+| [SRD0701](Design/SRD0701.md) | Database QUERY_STORE option is not READ_WRITE |   | Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store. (Use `<QueryStoreDesiredState>ReadWrite</QueryStoreDesiredState>` for MsBuild.Sdk.SqlProj projects.) |   |
 | [SRD0703](Design/SRD0703.md) | Database QUERY_STORE_CAPTURE_MODE option is not AUTO |   | Set `<QueryStoreCaptureMode>AUTO</QueryStoreCaptureMode>` in the project file to enable QUERY_STORE_CAPTURE_MODE = AUTO. |   |
 | [SRD0704](Design/SRD0704.md) | Database TARGET_RECOVERY_TIME option is not set |   | Set `<TargetRecoveryTimePeriod>60</TargetRecoveryTimePeriod>` in the project file to enable TARGET_RECOVERY_TIME. |   |
 | [SRD0705](Design/SRD0705.md) | Database AUTO_CLOSE option is not OFF |   | Set `<AutoClose>False</AutoClose>` in the project file to disable AUTO_CLOSE. |   |

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -88,7 +88,7 @@
 | [SRD0094](Design/SRD0094.md) | Avoid named foreign keys on temporary tables | Yes | Foreign key constraints on temp tables should not be named. |   |
 | [SRD0095](Design/SRD0095.md) | Named check constraints on temp tables | Yes | Check constraints on temp tables should not be named. | Yes |
 | [SRD0096](Design/SRD0096.md) | Potential SQL injection issue |   | Potential SQL injection issue. | Yes |
-| [SRD0700](Design/SRD0700.md) | Database PAGE_VERIFY option is not CHECKSUM |   | Set '<PageVerify>CHECKSUM</PageVerify>' in the project file to enable PAGE_VERIFY = CHECKSUM. (Use '<PageVerifyMode>Checksum</PageVerifyMode>' for MsBuild.Sdk.SqlProj projects.) |   |
+| [SRD0700](Design/SRD0700.md) | Database PAGE_VERIFY option is not CHECKSUM |   | Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM. (Use `<PageVerifyMode>Checksum</PageVerifyMode>` for MsBuild.Sdk.SqlProj projects.) |   |
 | [SRD0701](Design/SRD0701.md) | Database QUERY_STORE option is not READ_WRITE |   | Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store. (Use `<QueryStoreDesiredState>ReadWrite</QueryStoreDesiredState>` for MsBuild.Sdk.SqlProj projects.) |   |
 | [SRD0703](Design/SRD0703.md) | Database QUERY_STORE_CAPTURE_MODE option is not AUTO |   | Set `<QueryStoreCaptureMode>AUTO</QueryStoreCaptureMode>` in the project file to enable QUERY_STORE_CAPTURE_MODE = AUTO. |   |
 | [SRD0704](Design/SRD0704.md) | Database TARGET_RECOVERY_TIME option is not set |   | Set `<TargetRecoveryTimePeriod>60</TargetRecoveryTimePeriod>` in the project file to enable TARGET_RECOVERY_TIME. |   |

--- a/src/SqlServer.Rules/Design/PageVerifyChecksumRule.cs
+++ b/src/SqlServer.Rules/Design/PageVerifyChecksumRule.cs
@@ -33,7 +33,7 @@ namespace SqlServer.Rules.Design
         /// <summary>
         /// The rule display name
         /// </summary>
-        public const string RuleDisplayName = "Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM. (Use `<PageVerifyMode>Checksum</PageVerifyMode>` for MsBuild.Sdk.SqlProj projects.)";
+        public const string RuleDisplayName = "Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM. (Use `<PageVerifyMode>Checksum</PageVerifyMode>` for MSBuild.Sdk.SqlProj projects.)";
 
         /// <summary>
         /// The message

--- a/src/SqlServer.Rules/Design/PageVerifyChecksumRule.cs
+++ b/src/SqlServer.Rules/Design/PageVerifyChecksumRule.cs
@@ -33,7 +33,7 @@ namespace SqlServer.Rules.Design
         /// <summary>
         /// The rule display name
         /// </summary>
-        public const string RuleDisplayName = "Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM.";
+        public const string RuleDisplayName = "Set `<PageVerify>CHECKSUM</PageVerify>` in the project file to enable PAGE_VERIFY = CHECKSUM. (Use `<PageVerifyMode>Checksum</PageVerifyMode>` for MsBuild.Sdk.SqlProj projects.)";
 
         /// <summary>
         /// The message

--- a/src/SqlServer.Rules/Design/QueryStoreReadWriteRule.cs
+++ b/src/SqlServer.Rules/Design/QueryStoreReadWriteRule.cs
@@ -32,7 +32,7 @@ namespace SqlServer.Rules.Design
         /// <summary>
         /// The rule display name
         /// </summary>
-        public const string RuleDisplayName = "Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store.";
+        public const string RuleDisplayName = "Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store. (Use `<QueryStoreDesiredState>ReadWrite</QueryStoreDesiredState>` for MsBuild.Sdk.SqlProj projects.)";
 
         /// <summary>
         /// The message

--- a/src/SqlServer.Rules/Design/QueryStoreReadWriteRule.cs
+++ b/src/SqlServer.Rules/Design/QueryStoreReadWriteRule.cs
@@ -32,7 +32,7 @@ namespace SqlServer.Rules.Design
         /// <summary>
         /// The rule display name
         /// </summary>
-        public const string RuleDisplayName = "Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store. (Use `<QueryStoreDesiredState>ReadWrite</QueryStoreDesiredState>` for MsBuild.Sdk.SqlProj projects.)";
+        public const string RuleDisplayName = "Set `<QueryStoreDesiredState>READ_WRITE</QueryStoreDesiredState>` in the project file to enable Query Store. (Use `<QueryStoreDesiredState>ReadWrite</QueryStoreDesiredState>` for MSBuild.Sdk.SqlProj projects.)";
 
         /// <summary>
         /// The message


### PR DESCRIPTION
Update SRD0700 and SRD0701 rule display names to specify correct property names and casing for MsBuild.Sdk.SqlProj projects.

This improves guidance for configuring PAGE_VERIFY and QUERY_STORE options in different project types.

fixes #533

@nmummau FYI
