### PR TITLE
Support ad-hoc T-SQL script analysis via batch wrapping

### DIFF
--- a/investigations/cli-non-object-scripts.md
+++ b/investigations/cli-non-object-scripts.md
@@ -197,9 +197,8 @@ All changes are confined to the engine's model-building path plus options:
 ## Implementation (as built)
 
 Option A was implemented as an **always-on, transparent** behavior (sub-option
-A1). No new CLI switch was added; library consumers can opt out via
-`AnalyzerOptions.WrapAdhocBatches` (default `true`). The MCP tool was changed to
-follow the same path.
+A1). No new CLI switch was added; ad-hoc wrapping is applied automatically for
+file and text inputs, including the MCP tool.
 
 - **`Services/BatchWrapper.cs`** (new) — parses the script with `TSql170Parser`
   and, for each `GO`-separated batch whose statements are all in an allow-list of

--- a/investigations/cli-non-object-scripts.md
+++ b/investigations/cli-non-object-scripts.md
@@ -1,0 +1,249 @@
+# Proposal: Analyzing non–object-creation scripts in the CLI
+
+Status: **implemented** (Option A)
+Scope: `tools/SqlAnalyzerCli` + `tools/ErikEJ.DacFX.TSQLAnalyzer`
+
+## Problem
+
+`tsqlanalyze` (and the underlying `ErikEJ.DacFX.TSQLAnalyzer` engine) can only
+analyze **object-creation scripts** — files whose batches are `CREATE TABLE`,
+`CREATE PROCEDURE`, `CREATE VIEW`, `CREATE FUNCTION`, etc.
+
+Scripts that are *not* object definitions cannot be analyzed today:
+
+- ad-hoc query / investigation scripts (`SELECT * FROM ...`, `UPDATE ...`)
+- migration / deployment / post-deploy scripts (`INSERT`, `MERGE`, `EXEC`, `GO`-separated batches)
+- maintenance scripts (`ALTER`, index rebuilds, `DBCC`, dynamic SQL)
+
+For these inputs the tool either reports a model error or silently finds zero
+problems — even though many design/performance rules (`SELECT *`, `NOLOCK`,
+positional `ORDER BY`, non-SARGable predicates, etc.) apply just as well inside
+an ad-hoc batch as inside a stored procedure body.
+
+## Root cause
+
+The engine is **model-based**. DacFx code analysis runs against a `TSqlModel`,
+and rules execute against the *elements* in that model (`SqlRuleScope.Element`)
+or the model as a whole (`SqlRuleScope.Model`).
+
+The model is populated exclusively from object definitions:
+
+| Where | Call |
+|---|---|
+| `AnalyzerFactory.AddFilesToModel` | `model.AddOrUpdateObjects(fileContents, fileName, …)` (`AnalyzerFactory.cs:224`) |
+| `AnalyzerFactory.AddScriptToModel` | `model.AddObjects(script, …)` (`AnalyzerFactory.cs:238`) |
+
+`AddObjects` / `AddOrUpdateObjects` only materialize **schema objects**. A batch
+such as `SELECT * FROM dbo.Foo;` contributes no element to the model, so there
+is nothing for an element-scoped rule to visit. The MCP tool makes this contract
+explicit and rejects anything else:
+
+```csharp
+// AnalyzerTools.cs:22
+if (!sqlScript.Trim().StartsWith("CREATE ", StringComparison.OrdinalIgnoreCase))
+{
+    return "The script must be an object creation script starting with 'CREATE'";
+}
+```
+
+So the limitation is architectural, not a missing CLI flag.
+
+## Options considered
+
+### Option A — Auto-wrap ad-hoc batches in a synthetic stored procedure (recommended)
+
+Before adding a batch to the model, detect whether its top-level statement is an
+object definition. If it is, add it as-is (current behavior). If it is **not**,
+wrap the batch body in a generated, throw-away procedure so it becomes a model
+element:
+
+```sql
+CREATE PROCEDURE [__tsqlanalyzer].[adhoc_<n>]
+AS
+BEGIN
+    <original batch text>
+END
+```
+
+The procedure body is exactly the kind of element the existing rules already
+analyze, so the bulk of the design/performance ruleset starts firing against
+ad-hoc T-SQL **with no rule changes**.
+
+Pros:
+- Reuses the entire existing engine and ruleset.
+- Smallest, lowest-risk change; isolated to the model-building path.
+- Matches the technique the rules were designed for (procedure bodies).
+
+Cons / things to handle:
+- **Line-number remapping.** The wrapper prefixes lines; every reported
+  `StartLine` for a wrapped batch must be shifted back by the number of prefix
+  lines (and offset by the batch's position within the file). Reported
+  `SourceName` must map back to the real file, not the synthetic object.
+- **Not every statement is legal inside a procedure body.** Batch-only
+  constructs (`USE`, `SET SHOWPLAN_*`, `CREATE/ALTER` of certain objects,
+  `BACKUP`, etc.) fail when nested. These batches should be skipped (and
+  optionally surfaced as "not analyzable") rather than aborting the whole file.
+- **Batch separation.** Files are `GO`-delimited. Wrap each batch independently
+  so one un-wrappable batch doesn't lose the rest.
+- Rules whose semantics are "an object named X should…" (naming rules,
+  cross-object model rules) are meaningless for the synthetic object and should
+  be excluded from wrapped batches (see *Rule applicability* below).
+
+### Option B — ScriptDom-only (model-less) analysis path
+
+Run a curated subset of rules directly over the ScriptDom AST, bypassing the
+DacFx code-analysis service entirely.
+
+Pros: no synthetic objects, no line remapping.
+Cons: the rules in this repo inherit from `BaseSqlCodeAnalysisRule` /
+`SqlCodeAnalysisRule` and rely on model context (e.g. `GetDataType` /
+`GetColumnDataType` resolve column types from the model). Only rules that are
+purely syntactic could run; everything that needs type/column resolution would
+have to be re-implemented or skipped. This is a large rework for partial
+coverage and is **not recommended** as the first step.
+
+### Option C — Document the limitation only
+
+Make the constraint explicit in `readme.md` and the MCP error message and stop
+there. Lowest effort, no new capability. Acceptable as a stop-gap but does not
+solve the request.
+
+## Recommendation
+
+Implement **Option A**. It unlocks the most rules for the least risk and keeps
+a single analysis engine.
+
+## Rule applicability (Option A)
+
+Three buckets once a batch is wrapped:
+
+| Bucket | Behavior |
+|---|---|
+| Design / performance rules that inspect statement bodies (`SELECT *`, `NOLOCK`, positional `ORDER BY`, `EXEC` dynamic SQL, non-SARGable predicates, cursors, `WAITFOR DELAY`, …) | **Fire normally** — primary value of this feature. |
+| Naming rules (`SRN*`) that judge the object's own name/shape | **Suppress** for synthetic wrappers — the generated name is not the user's. |
+| Whole-model / cross-object rules (`SqlRuleScope.Model`, e.g. missing-PK, FK-index) | **Suppress / best-effort** — no real schema is present for ad-hoc input. |
+
+Suppression can reuse the existing problem-suppressor mechanism already wired in
+`AnalyzerFactory.Analyze` (`service.SetProblemSuppressor(...)`, `AnalyzerFactory.cs:63`)
+combined with the synthetic schema/object name.
+
+## Proposed CLI surface
+
+Two sub-options; **A1 is preferred**.
+
+- **A1 — automatic.** No new switch. When a batch is not an object definition,
+  the engine wraps it transparently. "Just works" for the SSMS external-tool and
+  ad-hoc-file scenarios. Add a one-line note to output that *N* batches were
+  analyzed as ad-hoc.
+
+- **A2 — opt-in switch.** Add `--adhoc` (`-A`) to `CliAnalyzerOptions` /
+  `AnalyzerOptions`, off by default, to preserve today's strict behavior unless
+  requested:
+
+  ```bash
+  ## Analyze an ad-hoc / migration script (no CREATE wrapper)
+  tsqlanalyze -i C:\scripts\migration_042.sql --adhoc
+  ```
+
+A pragmatic combination: default to A1 for `.sql` *files/folders* and the `-t`
+text input, but keep the MCP `FindSqlScriptProblems` contract opt-in so existing
+callers are unaffected.
+
+## Implementation sketch
+
+All changes are confined to the engine's model-building path plus options:
+
+1. **`ErikEJ.DacFX.TSQLAnalyzer/Services`** — add a `BatchWrapper` helper:
+   - Parse input with ScriptDom (`TSqlParser` for the requested `SqlVersion`)
+     into `GO`-separated batches.
+   - For each batch, inspect the top-level `TSqlStatement`: if it is a
+     `CreateXxxStatement` → keep verbatim; else wrap in the synthetic procedure
+     and record `(realFile, lineOffset)`.
+   - Skip batches that are illegal inside a procedure body; collect them as
+     "not analyzable" diagnostics.
+
+2. **`AnalyzerFactory.AddFilesToModel` / `AddScriptToModel`** — route content
+   through `BatchWrapper` before `AddObjects` / `AddOrUpdateObjects`
+   (`AnalyzerFactory.cs:210`, `:233`). Keep a map from synthetic object →
+   `(originalFile, lineOffset)`.
+
+3. **Result post-processing** — when emitting problems
+   (`AnalyzerFactory.SaveOutputFile` and the console loop in `Program.Run`,
+   `Program.cs:205`), translate synthetic `SourceName`/`StartLine` back to the
+   real file and line using the map, and apply the rule-bucket suppression.
+
+4. **Options** — add `Adhoc` to `AnalyzerOptions` and a matching
+   `-A/--adhoc` option in `CliAnalyzerOptions` if A2 is chosen; otherwise wire
+   A1 unconditionally for file/text input.
+
+5. **MCP** — relax `AnalyzerTools.FindSqlScriptProblems` (`AnalyzerTools.cs:22`):
+   keep accepting `CREATE` scripts, but when `--adhoc`/wrapping is enabled,
+   analyze non-`CREATE` scripts too and adjust the description text.
+
+6. **Docs / help** — add an "Analyze an ad-hoc script" sample to
+   `Program.DisplayHelp` (`Program.cs:277`) and to `readme.md`, and note the
+   line-remapping + suppressed-rule caveats.
+
+## Tests
+
+- New fixtures under `sqlprojects/` containing ad-hoc batches (DML, `GO`-separated
+  multi-batch, one un-wrappable batch mixed with analyzable ones).
+- Engine tests in `test/TSQLAnalyzer.Tests` asserting:
+  - design/perf rules fire on wrapped batches,
+  - reported line numbers map back to the **original** file lines,
+  - naming / model-scope rules are suppressed for synthetic objects,
+  - un-wrappable batches are reported as not-analyzable, not fatal.
+
+## Implementation (as built)
+
+Option A was implemented as an **always-on, transparent** behavior (sub-option
+A1). No new CLI switch was added; library consumers can opt out via
+`AnalyzerOptions.WrapAdhocBatches` (default `true`). The MCP tool was changed to
+follow the same path.
+
+- **`Services/BatchWrapper.cs`** (new) — parses the script with `TSql170Parser`
+  and, for each `GO`-separated batch whose statements are all in an allow-list of
+  body-legal DML / control-flow statements, splices
+  `CREATE PROCEDURE [dbo].[__tsqlanalyzer_adhoc_batch_N] AS BEGIN … END` around
+  the batch. The prefix/suffix are inserted **inline (no new lines)**, so the
+  approach needs *no* line-offset map — every reported `StartLine` already
+  matches the real source line. (Only the column on a wrapped batch's first line
+  shifts.) Object definitions and batches containing batch-only statements are
+  left untouched; unparseable input is returned verbatim (unchanged behavior).
+- **`AnalyzerFactory`** — `AddFilesToModel` / `AddScriptToModel` route content
+  through `BatchWrapper.Wrap` before `AddOrUpdateObjects` / `AddObjects`. The
+  problem suppressor now also drops naming rules (`SRN*`, `SR0011/0012/0016`) and
+  procedure-shape rules (`SRP0005` SET NOCOUNT ON) when they are raised against a
+  synthetic `__tsqlanalyzer_adhoc_batch_*` object, keyed off
+  `SqlRuleProblemSuppressionContext.ModelElement`.
+- **`AnalyzerTools.FindSqlScriptProblems`** (MCP) — the `CREATE`-prefix gate was
+  removed; ad-hoc batches are analyzed too.
+
+Verified: the rule + smoke test suites (106 tests) and the analyzer-engine tests
+remain green (DDL-only fixtures are unaffected); a multi-batch DML script now
+reports `SELECT *`, single-char-alias, `IN`-subquery and semicolon problems at
+their real line numbers, with no synthetic-wrapper noise.
+
+Tests (added): `test/TSQLAnalyzer.Tests/BatchWrapperTests.cs` covers `BatchWrapper.Wrap`
+directly (object definitions left unchanged, DML batches wrapped, inline wrapping
+preserves line count, each `GO`-separated batch wrapped independently, object
+definitions and batch-only statements left untouched, unparseable input returned
+verbatim). `test/TSQLAnalyzer.Tests/AdhocAnalysisTests.cs` covers the engine end to
+end against new fixtures under `sqlprojects/AdhocScripts/` (design rules fire on
+wrapped batches, reported line numbers map back to the original source line,
+naming / `SRP0005` / synthetic-object noise is suppressed, every `GO`-separated
+batch is analyzed, and a mixed real-object + ad-hoc file analyzes without fatal
+model errors). `BatchWrapper` is exposed to the test project via `InternalsVisibleTo`.
+
+Not yet done: CLI `--help` sample and `readme.md` note.
+
+## Open questions
+
+- Should the synthetic-object schema (`__tsqlanalyzer`) be configurable to avoid
+  collisions if a user's ad-hoc script references such a name? (Use a GUID-ish
+  suffix to be safe.)
+- For multi-batch files that mix real `CREATE` objects and ad-hoc batches, do we
+  analyze both in the same model run, or two passes? (Single pass is feasible and
+  preferred.)
+- How to present per-batch "not analyzable" notices without adding noise to the
+  problem list (separate summary line vs. dedicated diagnostic).

--- a/sqlprojects/AdhocScripts/AdhocDml.sql
+++ b/sqlprojects/AdhocScripts/AdhocDml.sql
@@ -1,0 +1,4 @@
+﻿-- ad-hoc investigation script (not an object definition)
+-- the SELECT * on the next line should trigger SRD0006
+SELECT *
+FROM sys.objects;

--- a/sqlprojects/AdhocScripts/AdhocMixed.sql
+++ b/sqlprojects/AdhocScripts/AdhocMixed.sql
@@ -1,0 +1,12 @@
+﻿-- a real object definition mixed with an ad-hoc batch.
+-- the CREATE TABLE batch is left untouched (added as a real object),
+-- while the SELECT * batch is wrapped so design rules fire on it.
+CREATE TABLE dbo.AdhocMixedFoo
+(
+    Id INT NOT NULL,
+    CONSTRAINT PK_AdhocMixedFoo PRIMARY KEY CLUSTERED (Id)
+);
+GO
+SELECT *
+FROM dbo.AdhocMixedFoo;
+GO

--- a/sqlprojects/AdhocScripts/AdhocMultiBatch.sql
+++ b/sqlprojects/AdhocScripts/AdhocMultiBatch.sql
@@ -1,0 +1,7 @@
+﻿-- multiple GO-separated ad-hoc batches, each wrapped independently
+SELECT *
+FROM sys.objects;
+GO
+SELECT *
+FROM sys.columns;
+GO

--- a/test/TSQLAnalyzer.Tests/AdhocAnalysisTests.cs
+++ b/test/TSQLAnalyzer.Tests/AdhocAnalysisTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using ErikEJ.DacFX.TSQLAnalyzer;
+using ErikEJ.DacFX.TSQLAnalyzer.Services;
+using Microsoft.SqlServer.Dac.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SqlServer.Rules.Tests.Docs;
+
+[TestClass]
+[TestCategory("Analyzer")]
+public class AdhocAnalysisTests
+{
+    private const string SelectStarRuleId = "SqlServer.Rules.SRD0006";
+
+    [TestMethod]
+    public void DesignRulesFireOnWrappedAdhocBatch()
+    {
+        // A plain ad-hoc query, not an object definition.
+        var result = Analyze(new AnalyzerOptions
+        {
+            Script = "SELECT * FROM sys.objects;",
+            SqlVersion = SqlServerVersion.Sql160,
+        });
+
+        // The SELECT * design rule fires even though there is no CREATE statement.
+        Assert.IsNotEmpty(result.Result!.Problems, "Expected design problems on the ad-hoc batch.");
+        Assert.IsTrue(
+            result.Result.Problems.Any(p => p.RuleId == SelectStarRuleId),
+            $"Expected {SelectStarRuleId} (Avoid SELECT *) to fire on the wrapped ad-hoc batch.");
+    }
+
+    [TestMethod]
+    public void NamingAndSyntheticObjectNoiseIsSuppressed()
+    {
+        var result = Analyze(new AnalyzerOptions
+        {
+            Script = "SELECT * FROM sys.objects;",
+            SqlVersion = SqlServerVersion.Sql160,
+        });
+
+        foreach (var problem in result.Result!.Problems)
+        {
+            Assert.IsFalse(
+                problem.RuleId.Contains(".SRN", StringComparison.OrdinalIgnoreCase),
+                $"Naming rule {problem.RuleId} should be suppressed for synthetic ad-hoc objects.");
+            Assert.AreNotEqual(
+                "SqlServer.Rules.SRP0005",
+                problem.RuleId,
+                "SET NOCOUNT ON (SRP0005) should be suppressed for synthetic ad-hoc objects.");
+            Assert.IsFalse(
+                (problem.SourceName ?? string.Empty).Contains(BatchWrapper.SyntheticObjectPrefix, StringComparison.Ordinal),
+                "Problems must not reference the synthetic wrapper object name.");
+        }
+    }
+
+    [TestMethod]
+    public void ReportedLineNumbersMapToOriginalSource()
+    {
+        // The fixture has `SELECT *` on line 3 (after two comment lines).
+        var result = Analyze(new AnalyzerOptions
+        {
+            Scripts = ["../../../../../sqlprojects/AdhocScripts/AdhocDml.sql"],
+            SqlVersion = SqlServerVersion.Sql160,
+        });
+
+        var selectStar = result.Result!.Problems.FirstOrDefault(p => p.RuleId == SelectStarRuleId);
+
+        Assert.IsNotNull(selectStar, $"Expected {SelectStarRuleId} to fire on the ad-hoc file.");
+        Assert.AreEqual(
+            3,
+            selectStar.StartLine,
+            "Inline wrapping must keep the reported line number aligned with the original source line.");
+    }
+
+    [TestMethod]
+    public void EveryGoSeparatedBatchIsAnalyzed()
+    {
+        var result = Analyze(new AnalyzerOptions
+        {
+            Scripts = ["../../../../../sqlprojects/AdhocScripts/AdhocMultiBatch.sql"],
+            SqlVersion = SqlServerVersion.Sql160,
+        });
+
+        // Both GO-separated SELECT * batches should be flagged.
+        Assert.AreEqual(
+            2,
+            result.Result!.Problems.Count(p => p.RuleId == SelectStarRuleId),
+            "Each wrapped ad-hoc batch should be analyzed independently.");
+    }
+
+    [TestMethod]
+    public void RealObjectAndAdhocBatchCoexistWithoutError()
+    {
+        // A real CREATE TABLE batch mixed with an ad-hoc SELECT * batch must not abort analysis.
+        var result = Analyze(new AnalyzerOptions
+        {
+            Scripts = ["../../../../../sqlprojects/AdhocScripts/AdhocMixed.sql"],
+            SqlVersion = SqlServerVersion.Sql160,
+        });
+
+        Assert.IsTrue(result.Result!.AnalysisSucceeded, "Analysis should succeed for a mixed object/ad-hoc file.");
+        Assert.IsEmpty(result.ModelErrors, "Un-wrappable batches must not produce fatal model errors.");
+        Assert.IsTrue(
+            result.Result.Problems.Any(p => p.RuleId == SelectStarRuleId),
+            "The ad-hoc SELECT * batch should still be analyzed alongside the real object.");
+    }
+
+    private static AnalyzerResult Analyze(AnalyzerOptions options)
+    {
+        var analysis = new AnalyzerFactory(options).Analyze();
+
+        Assert.IsNotNull(analysis);
+        Assert.IsNotNull(analysis.Result);
+
+        return analysis;
+    }
+}

--- a/test/TSQLAnalyzer.Tests/BatchWrapperTests.cs
+++ b/test/TSQLAnalyzer.Tests/BatchWrapperTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Linq;
+using ErikEJ.DacFX.TSQLAnalyzer.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SqlServer.Rules.Tests.Docs;
+
+[TestClass]
+[TestCategory("Analyzer")]
+public class BatchWrapperTests
+{
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    public void WrapReturnsInputForNullOrWhitespace(string sql)
+    {
+        Assert.AreEqual(sql, BatchWrapper.Wrap(sql));
+    }
+
+    [TestMethod]
+    public void WrapLeavesProcedureDefinitionUnchanged()
+    {
+        var sql = "CREATE PROCEDURE dbo.TestProc AS SELECT 1;";
+
+        Assert.AreEqual(sql, BatchWrapper.Wrap(sql));
+    }
+
+    [TestMethod]
+    public void WrapLeavesTableDefinitionUnchanged()
+    {
+        var sql = "CREATE TABLE dbo.Foo (Id INT NOT NULL);";
+
+        Assert.AreEqual(sql, BatchWrapper.Wrap(sql));
+    }
+
+    [TestMethod]
+    public void WrapEnclosesDmlBatchInSyntheticProcedure()
+    {
+        var sql = "SELECT * FROM sys.objects;";
+
+        var wrapped = BatchWrapper.Wrap(sql);
+
+        Assert.AreNotEqual(sql, wrapped);
+        StringAssert.Contains(wrapped, $"CREATE PROCEDURE [dbo].[{BatchWrapper.SyntheticObjectPrefix}1] AS BEGIN ", StringComparison.Ordinal);
+        StringAssert.Contains(wrapped, "SELECT * FROM sys.objects;", StringComparison.Ordinal);
+        StringAssert.EndsWith(wrapped, " END", StringComparison.Ordinal);
+    }
+
+    [TestMethod]
+    public void WrapDoesNotAddLinesSoOriginalLineNumbersArePreserved()
+    {
+        var sql = "-- a comment\nSELECT *\nFROM sys.objects;\n";
+
+        var wrapped = BatchWrapper.Wrap(sql);
+
+        Assert.AreNotEqual(sql, wrapped);
+        Assert.AreEqual(
+            sql.Count(c => c == '\n'),
+            wrapped.Count(c => c == '\n'),
+            "Wrapping must be inline so reported line numbers still match the original source.");
+    }
+
+    [TestMethod]
+    public void WrapEnclosesEachAdhocBatchIndependently()
+    {
+        var sql = "SELECT * FROM sys.objects;\nGO\nUPDATE dbo.Foo SET Id = 1;\nGO\n";
+
+        var wrapped = BatchWrapper.Wrap(sql);
+
+        StringAssert.Contains(wrapped, $"[{BatchWrapper.SyntheticObjectPrefix}1]", StringComparison.Ordinal);
+        StringAssert.Contains(wrapped, $"[{BatchWrapper.SyntheticObjectPrefix}2]", StringComparison.Ordinal);
+    }
+
+    [TestMethod]
+    public void WrapLeavesObjectDefinitionUntouchedAmongAdhocBatches()
+    {
+        var sql = "CREATE TABLE dbo.Foo (Id INT NOT NULL);\nGO\nSELECT * FROM dbo.Foo;\nGO\n";
+
+        var wrapped = BatchWrapper.Wrap(sql);
+
+        // The object definition keeps exactly one CREATE TABLE and is not nested in a procedure.
+        StringAssert.Contains(wrapped, "CREATE TABLE dbo.Foo (Id INT NOT NULL);", StringComparison.Ordinal);
+
+        // Only the ad-hoc DML batch is wrapped, so there is a single synthetic procedure.
+        StringAssert.Contains(wrapped, $"[{BatchWrapper.SyntheticObjectPrefix}1]", StringComparison.Ordinal);
+        Assert.IsFalse(
+            wrapped.Contains($"[{BatchWrapper.SyntheticObjectPrefix}2]", StringComparison.Ordinal),
+            "The object-definition batch must not be wrapped.");
+    }
+
+    [TestMethod]
+    public void WrapLeavesBatchOnlyStatementUntouched()
+    {
+        // USE is a batch-only statement that is illegal inside a procedure body, so it is not wrapped.
+        var sql = "USE master;";
+
+        Assert.AreEqual(sql, BatchWrapper.Wrap(sql));
+    }
+
+    [TestMethod]
+    public void WrapReturnsUnparseableInputVerbatim()
+    {
+        var sql = "this is not valid t-sql @@@";
+
+        Assert.AreEqual(sql, BatchWrapper.Wrap(sql));
+    }
+}

--- a/tools/ErikEJ.DacFX.TSQLAnalyzer/AnalyzerFactory.cs
+++ b/tools/ErikEJ.DacFX.TSQLAnalyzer/AnalyzerFactory.cs
@@ -57,12 +57,7 @@ public class AnalyzerFactory
 
         result.Analyzers = string.Join(", ", rules.Select(a => a.Namespace).Distinct());
 
-        if (ignoredRules.Count > 0
-                    || ignoredRuleSets.Count > 0)
-        {
-            service.SetProblemSuppressor(p => ignoredRules.Contains(p.Rule.RuleId)
-                || ignoredRuleSets.Any(s => p.Rule.RuleId.StartsWith(s, StringComparison.OrdinalIgnoreCase)));
-        }
+        service.SetProblemSuppressor(IsSuppressed);
 
         var analysisResult = service.Analyze(model);
 
@@ -218,10 +213,10 @@ public class AnalyzerFactory
 
         foreach (var (fileName, fileContents) in files)
         {
-            var options = new TSqlObjectOptions();
+            var contents = BatchWrapper.Wrap(fileContents);
             try
             {
-                model.AddOrUpdateObjects(fileContents, fileName, new TSqlObjectOptions());
+                model.AddOrUpdateObjects(contents, fileName, new TSqlObjectOptions());
             }
             catch (DacModelException dex)
             {
@@ -232,10 +227,10 @@ public class AnalyzerFactory
 
     private static void AddScriptToModel(AnalyzerResult result, TSqlModel model, string script)
     {
-        var options = new TSqlObjectOptions();
+        var contents = BatchWrapper.Wrap(script);
         try
         {
-            model.AddObjects(script, new TSqlObjectOptions());
+            model.AddObjects(contents, new TSqlObjectOptions());
         }
         catch (DacModelException dex)
         {
@@ -251,6 +246,65 @@ public class AnalyzerFactory
                     LoadAsScriptBackedModel = true,
                     ModelStorageType = DacSchemaModelStorageType.Memory,
                 });
+
+    // Rules that only make sense for a real, named programmable object and are therefore pure
+    // noise when raised against the synthetic procedure that wraps an ad-hoc batch.
+    private static readonly HashSet<string> SyntheticObjectShapeRules = new(StringComparer.Ordinal)
+    {
+        "SqlServer.Rules.SRP0005", // SET NOCOUNT ON recommended in stored procedures and triggers
+    };
+
+    private static bool IsNamingRule(string ruleId)
+        => ruleId.Contains(".SRN", StringComparison.OrdinalIgnoreCase)
+            || ruleId.EndsWith("SR0011", StringComparison.Ordinal)
+            || ruleId.EndsWith("SR0012", StringComparison.Ordinal)
+            || ruleId.EndsWith("SR0016", StringComparison.Ordinal);
+
+    private static bool IsSyntheticAdhocElement(TSqlObject? element)
+    {
+        if (element == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return element.Name?.Parts?.Any(
+                p => p.StartsWith(BatchWrapper.SyntheticObjectPrefix, StringComparison.Ordinal)) == true;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+        {
+            // Some model elements do not expose a name; treat those as non-synthetic.
+            return false;
+        }
+    }
+
+    private bool IsSuppressed(SqlRuleProblemSuppressionContext context)
+    {
+        var ruleId = context.Rule.RuleId;
+
+        if (ignoredRules.Contains(ruleId))
+        {
+            return true;
+        }
+
+        if (ignoredRuleSets.Any(s => ruleId.StartsWith(s, StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        // Naming and procedure-shape rules raised against the generated wrapper procedure relate to
+        // the synthetic object, not the user's ad-hoc script, so they are dropped as noise.
+        if ((IsNamingRule(ruleId) || SyntheticObjectShapeRules.Contains(ruleId))
+            && IsSyntheticAdhocElement(context.ModelElement))
+        {
+            return true;
+        }
+
+        return false;
+    }
 
     private void BuildRuleLists(string rulesExpression)
     {

--- a/tools/ErikEJ.DacFX.TSQLAnalyzer/ErikEJ.DacFX.TSQLAnalyzer.csproj
+++ b/tools/ErikEJ.DacFX.TSQLAnalyzer/ErikEJ.DacFX.TSQLAnalyzer.csproj
@@ -35,4 +35,8 @@
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="TSQLAnalyzer.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tools/ErikEJ.DacFX.TSQLAnalyzer/Services/BatchWrapper.cs
+++ b/tools/ErikEJ.DacFX.TSQLAnalyzer/Services/BatchWrapper.cs
@@ -1,0 +1,152 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace ErikEJ.DacFX.TSQLAnalyzer.Services;
+
+/// <summary>
+/// Wraps ad-hoc (non object-creation) T-SQL batches in throw-away stored procedures so that the
+/// model-based DacFx code-analysis rules, which only run against schema objects, can be applied
+/// to scripts such as migration, deployment and investigation scripts.
+/// </summary>
+/// <remarks>
+/// The wrapper text is inserted inline (without adding any new lines) at the start and end of each
+/// batch, so every original line keeps its number and reported problems still point at the real
+/// source line. Batches that already are object definitions, or that contain statements that are
+/// illegal inside a procedure body, are left untouched.
+/// </remarks>
+internal sealed class BatchWrapper
+{
+    /// <summary>
+    /// Object name prefix used for the generated procedures. Problem suppression matches on this
+    /// prefix to drop noise (e.g. naming violations) raised against the synthetic objects, so keep
+    /// the two in sync.
+    /// </summary>
+    public const string SyntheticObjectPrefix = "__tsqlanalyzer_adhoc_batch_";
+
+    /// <summary>
+    /// Returns <paramref name="sql"/> with every wrappable ad-hoc batch enclosed in a synthetic
+    /// stored procedure. If the script cannot be parsed, or contains nothing to wrap, the original
+    /// text is returned unchanged.
+    /// </summary>
+    /// <param name="sql">The T-SQL script to process.</param>
+    /// <returns>The script with ad-hoc batches wrapped, or the original text when nothing was wrapped.</returns>
+    public static string Wrap(string sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            return sql;
+        }
+
+        var script = TryParse(sql);
+
+        if (script == null)
+        {
+            return sql;
+        }
+
+        // Collect the edits first, then apply them right-to-left so earlier offsets stay valid.
+        var edits = new List<(int Offset, string Text)>();
+        var index = 0;
+
+        foreach (var batch in script.Batches)
+        {
+            if (batch.Statements.Count == 0 || !IsWrappable(batch))
+            {
+                continue;
+            }
+
+            index++;
+            var name = string.Create(CultureInfo.InvariantCulture, $"[dbo].[{SyntheticObjectPrefix}{index}]");
+
+            edits.Add((batch.StartOffset, $"CREATE PROCEDURE {name} AS BEGIN "));
+            edits.Add((batch.StartOffset + batch.FragmentLength, " END"));
+        }
+
+        if (edits.Count == 0)
+        {
+            return sql;
+        }
+
+        var builder = new StringBuilder(sql);
+
+        foreach (var (offset, text) in edits.OrderByDescending(e => e.Offset))
+        {
+            builder.Insert(offset, text);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool IsWrappable(TSqlBatch batch)
+    {
+        foreach (var statement in batch.Statements)
+        {
+            if (!IsWrappableStatement(statement))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // Allow-list of statements that are both valuable to analyze and legal inside a procedure body.
+    // Anything outside this set (object definitions, batch-only statements like USE / ALTER
+    // DATABASE, etc.) leaves the batch untouched so it is added to the model as-is.
+    private static bool IsWrappableStatement(TSqlStatement statement) => statement switch
+    {
+        SelectStatement => true,
+        InsertStatement => true,
+        UpdateStatement => true,
+        DeleteStatement => true,
+        MergeStatement => true,
+        ExecuteStatement => true,
+        DeclareVariableStatement => true,
+        DeclareTableVariableStatement => true,
+        SetVariableStatement => true,
+        IfStatement => true,
+        WhileStatement => true,
+        BeginEndBlockStatement => true,
+        TryCatchStatement => true,
+        PrintStatement => true,
+        ThrowStatement => true,
+        RaiseErrorStatement => true,
+        WaitForStatement => true,
+        DeclareCursorStatement => true,
+        OpenCursorStatement => true,
+        FetchCursorStatement => true,
+        CloseCursorStatement => true,
+        DeallocateCursorStatement => true,
+        BeginTransactionStatement => true,
+        CommitTransactionStatement => true,
+        RollbackTransactionStatement => true,
+        SaveTransactionStatement => true,
+        _ => false,
+    };
+
+    private static TSqlScript? TryParse(string sql)
+    {
+        try
+        {
+            // Use the newest parser and all engine types to support every SQL Server version.
+            var parser = new TSql170Parser(true, SqlEngineType.All);
+
+            using var reader = new StringReader(sql);
+            var fragment = parser.Parse(reader, out IList<ParseError> errors);
+
+            if (errors.Count > 0)
+            {
+                return null;
+            }
+
+            return fragment as TSqlScript;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+        {
+            return null;
+        }
+    }
+}

--- a/tools/SqlAnalyzerCli/.mcp/server.json
+++ b/tools/SqlAnalyzerCli/.mcp/server.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-  "description": "Find design problems and bad practices in a SQL Server CREATE script",
+  "description": "Analyzes T-SQL (SQL Server) scripts for design, naming, and performance problems and bad practices using the SqlServer.Rules static code-analysis ruleset, the same rules used by DacFx/SSDT. Lint stored procedures, functions, views, and CREATE/ALTER statements before deployment.",
   "name": "io.github.ErikEJ/SqlServer.Rules",
   "version": "1.1",
   "packages": [
     {
       "registryType": "nuget",
       "identifier": "ErikEJ.DacFX.TSQLAnalyzer.Cli",
-      "version": "1.1",
+      "version": "1.2",
       "registryBaseUrl": "https://api.nuget.org",
       "transport": {
         "type": "stdio"

--- a/tools/SqlAnalyzerCli/.mcp/server.json
+++ b/tools/SqlAnalyzerCli/.mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "description": "Analyzes T-SQL (SQL Server) scripts for design, naming, and performance problems and bad practices using the SqlServer.Rules static code-analysis ruleset, the same rules used by DacFx/SSDT. Lint stored procedures, functions, views, and CREATE/ALTER statements before deployment.",
   "name": "io.github.ErikEJ/SqlServer.Rules",
-  "version": "1.1",
+  "version": "1.2",
   "packages": [
     {
       "registryType": "nuget",

--- a/tools/SqlAnalyzerCli/Services/AnalyzerTools.cs
+++ b/tools/SqlAnalyzerCli/Services/AnalyzerTools.cs
@@ -8,20 +8,15 @@ namespace SqlAnalyzerCli.Services;
 public sealed class AnalyzerTools
 {
     [McpServerTool]
-    [Description("Find design problems and bad practices in a SQL Server CREATE script")]
+    [Description("Analyzes a T-SQL (SQL Server) script for design, naming, and performance problems and bad practices, using the SqlServer.Rules static code-analysis ruleset (the same rules used by DacFx/SSDT). Use this to review or lint SQL such as stored procedures, functions, views, and CREATE/ALTER statements before deploying them. Returns one line per problem found, each describing the rule, the location, and the issue.")]
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
     public static async Task<string> FindSqlScriptProblems(
-        [Description("The SQL Server CREATE script to find design problems and bad practices in.")] string sqlScript)
+        [Description("The complete T-SQL script to analyze, for example one or more CREATE/ALTER statements for stored procedures, functions, views, or tables. Provide the full script text, not a file path.")] string sqlScript)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
     {
         if (string.IsNullOrWhiteSpace(sqlScript))
         {
             return "No script specified, make sure to select one.";
-        }
-
-        if (!sqlScript.Trim().StartsWith("CREATE ", StringComparison.OrdinalIgnoreCase))
-        {
-            return "The script must be an object creation script starting with 'CREATE'";
         }
 
         var factory = new ErikEJ.DacFX.TSQLAnalyzer.AnalyzerFactory(new() { Script = sqlScript });


### PR DESCRIPTION
Adds BatchWrapper to wrap DML/control-flow batches in synthetic procedures, enabling code analysis on non-object scripts. Updates AnalyzerFactory to use the wrapper and suppresses noise from naming/shape rules on synthetic objects. Removes CREATE-only restriction in MCP tool. Adds tests and sample scripts for ad-hoc analysis, exposes internals for testing, bumps package version, and documents the approach.