### PR TITLE
Add VS settings for analyzer config and improve diagnostics

### DIFF
--- a/tools/SqlAnalyzerSsms/Linter/Tagging/SqlLintTagger.cs
+++ b/tools/SqlAnalyzerSsms/Linter/Tagging/SqlLintTagger.cs
@@ -118,7 +118,7 @@ namespace SqlAnalyzerSsms.Linter.Tagging
                 {
                     yield return new TagSpan<IErrorTag>(
                         span.Value,
-                        new ErrorTag(GetErrorType(result.Severity)));
+                        new ErrorTag(GetErrorType(result.Severity), result.Message));
                 }
             }
         }

--- a/tools/SqlAnalyzerVsix/SettingDefinitions.cs
+++ b/tools/SqlAnalyzerVsix/SettingDefinitions.cs
@@ -9,7 +9,7 @@ public static class SettingDefinitions
 {
 #pragma warning disable CEE0027 // String not localized
     [VisualStudioContribution]
-    private static SettingCategory AnalyzerCategory { get; } = new("sqlAnalyzerVisx", "T-SQL Analyzer");
+    private static SettingCategory AnalyzerCategory { get; } = new("sqlAnalyzerVsix", "T-SQL Analyzer");
 
     [VisualStudioContribution]
     public static Setting.Boolean RunAnalysis { get; } = new("runAnalysis", "Run static T-SQL analysis", AnalyzerCategory, defaultValue: true)

--- a/tools/SqlAnalyzerVsix/SettingDefinitions.cs
+++ b/tools/SqlAnalyzerVsix/SettingDefinitions.cs
@@ -1,0 +1,55 @@
+using Microsoft.VisualStudio.Extensibility;
+using Microsoft.VisualStudio.Extensibility.Settings;
+
+namespace SqlAnalyzerVsix;
+
+#pragma warning disable VSEXTPREVIEW_SETTINGS // The settings API is currently in preview and marked as experimental
+
+public static class SettingDefinitions
+{
+#pragma warning disable CEE0027 // String not localized
+    [VisualStudioContribution]
+    private static SettingCategory AnalyzerCategory { get; } = new("sqlAnalyzerVisx", "T-SQL Analyzer");
+
+    [VisualStudioContribution]
+    public static Setting.Boolean RunAnalysis { get; } = new("runAnalysis", "Run static T-SQL analysis", AnalyzerCategory, defaultValue: true)
+    {
+        Description = "Enable or disable static T-SQL analysis. When enabled, the extension will analyze your T-SQL code for design, naming and performance issues using more than 140 rules",
+    };
+
+    public static Setting.String Rules { get; } = new(
+        "rules",
+        "Rule exceptions",
+        AnalyzerCategory,
+        defaultValue: string.Empty)
+    {
+        Description = "Set the rules expression for live static SQL code analysis when no SQL project rule configuration is available (for example: '+!SqlServer.Rules.SRD0006;-SqlServer.Rules.SRN*')",
+    };
+
+    [VisualStudioContribution]
+    public static Setting.Enum SqlEngineVersion { get; } = new(
+        "sqlVersion",
+        "SQL engine version",
+        AnalyzerCategory,
+        [
+            new("Sql170", "SQL Server 2025 and Managed Instance"),
+            new("Sql160", "SQL Server 2022"),
+            new("SqlAzure", "Azure SQL Database"),
+            new("SqlDw", "Microsoft Azure SQL Data Warehouse"),
+            new("SqlServerless", "Azure Synapse Analytics Serverless SQL Pool"),
+            new("SqlDwUnified", "Fabric Data Warehouse"),
+            new("Sql150", "SQL Server 2019"),
+            new("Sql140", "SQL Server 2017"),
+            new("Sql130", "SQL Server 2016"),
+            new("Sql120", "SQL Server 2014"),
+            new("Sql110", "SQL Server 2012"),
+            new("Sql100", "SQL Server 2008"),
+            new("Sql90", "SQL Server 2005"),
+        ],
+        defaultValue: "Sql170")
+    {
+        Description = "Set the SQL Server dialect used in analysis",
+    };
+
+#pragma warning restore CEE0027 // String not localized
+}

--- a/tools/SqlAnalyzerVsix/SettingDefinitions.cs
+++ b/tools/SqlAnalyzerVsix/SettingDefinitions.cs
@@ -17,6 +17,7 @@ public static class SettingDefinitions
         Description = "Enable or disable static T-SQL analysis. When enabled, the extension will analyze your T-SQL code for design, naming and performance issues using more than 140 rules",
     };
 
+    [VisualStudioContribution]
     public static Setting.String Rules { get; } = new(
         "rules",
         "Rule exceptions",

--- a/tools/SqlAnalyzerVsix/SqlAnalyzerDiagnosticsService.cs
+++ b/tools/SqlAnalyzerVsix/SqlAnalyzerDiagnosticsService.cs
@@ -140,7 +140,7 @@ internal sealed class SqlAnalyzerDiagnosticsService : DisposableObject
 
             if (enabled)
             {
-                await this.ProcessDocumentAsync(textViewSnapshot.Document, runProperties.Rules, runProperties.SqlVersion, cancellationToken.CombineWith(newCts.Token).Token);
+                await this.ProcessDocumentAsync(textViewSnapshot.Document, rules, sqlVersion, cancellationToken.CombineWith(newCts.Token).Token);
             }
         }
     }

--- a/tools/SqlAnalyzerVsix/SqlAnalyzerDiagnosticsService.cs
+++ b/tools/SqlAnalyzerVsix/SqlAnalyzerDiagnosticsService.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Extensibility.Editor;
 using Microsoft.VisualStudio.Extensibility.Helpers;
 using Microsoft.VisualStudio.ProjectSystem.Query;
 using Microsoft.VisualStudio.Threading;
+using SqlAnalyzerVsix;
 
 namespace SqlAnalyzer;
 
@@ -75,11 +76,16 @@ internal sealed class SqlAnalyzerDiagnosticsService : DisposableObject
         {
             var runProperties = await this.IsInSqlProjAsync(documentUri.LocalPath, cancellationToken);
 
-            if (string.IsNullOrEmpty(runProperties.SqlVersion))
+            if (!runProperties.InSqlProj)
             {
-                runProperties.SqlVersion = "Sql170";
+#pragma warning disable VSEXTPREVIEW_SETTINGS // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            var results = await extensibility.Settings().ReadEffectiveValuesAsync(
+                [SettingDefinitions.Rules, SettingDefinitions.SqlEngineVersion],
+                cancellationToken);
 
-                // TODO set rules from options page if not set in project file
+            runProperties.SqlVersion = results.ValueOrDefault(SettingDefinitions.SqlEngineVersion, "Sql170");
+            runProperties.Rules = results.ValueOrDefault(SettingDefinitions.Rules, string.Empty);
+#pragma warning restore VSEXTPREVIEW_SETTINGS // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             }
 
             var diagnostics = await this.analyzerUtilities.RunAnalyzerOnFileAsync(documentUri, runProperties.Rules, runProperties.SqlVersion, cancellationToken);
@@ -116,9 +122,26 @@ internal sealed class SqlAnalyzerDiagnosticsService : DisposableObject
         }
 
         var runProperties = await this.IsInSqlProjAsync(textViewSnapshot.Uri.LocalPath, cancellationToken);
-        if (runProperties.Run)
+        if (runProperties.InSqlProj)
         {
             await this.ProcessDocumentAsync(textViewSnapshot.Document, runProperties.Rules, runProperties.SqlVersion, cancellationToken.CombineWith(newCts.Token).Token);
+        }
+        else
+        {
+#pragma warning disable VSEXTPREVIEW_SETTINGS // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            var results = await extensibility.Settings().ReadEffectiveValuesAsync(
+                [SettingDefinitions.Rules, SettingDefinitions.SqlEngineVersion, SettingDefinitions.RunAnalysis],
+                cancellationToken);
+
+            var sqlVersion = results.ValueOrDefault(SettingDefinitions.SqlEngineVersion, "Sql170");
+            var rules = results.ValueOrDefault(SettingDefinitions.Rules, string.Empty);
+            var enabled = results.ValueOrDefault(SettingDefinitions.RunAnalysis, false);
+#pragma warning restore VSEXTPREVIEW_SETTINGS // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+            if (enabled)
+            {
+                await this.ProcessDocumentAsync(textViewSnapshot.Document, runProperties.Rules, runProperties.SqlVersion, cancellationToken.CombineWith(newCts.Token).Token);
+            }
         }
     }
 
@@ -187,7 +210,7 @@ internal sealed class SqlAnalyzerDiagnosticsService : DisposableObject
         Assumes.NotNull(this.diagnosticsReporter);
     }
 
-    private async Task<(bool Run, string? Rules, string? SqlVersion)> IsInSqlProjAsync(string path, CancellationToken cancellationToken)
+    private async Task<(bool InSqlProj, string? Rules, string? SqlVersion)> IsInSqlProjAsync(string path, CancellationToken cancellationToken)
     {
         var workspace = this.extensibility.Workspaces();
 

--- a/tools/SqlAnalyzerVsix/SqlAnalyzerDiagnosticsService.cs
+++ b/tools/SqlAnalyzerVsix/SqlAnalyzerDiagnosticsService.cs
@@ -135,8 +135,7 @@ internal sealed class SqlAnalyzerDiagnosticsService : DisposableObject
 
             var sqlVersion = results.ValueOrDefault(SettingDefinitions.SqlEngineVersion, "Sql170");
             var rules = results.ValueOrDefault(SettingDefinitions.Rules, string.Empty);
-            var enabled = results.ValueOrDefault(SettingDefinitions.RunAnalysis, false);
-#pragma warning restore VSEXTPREVIEW_SETTINGS // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            var enabled = results.ValueOrDefault(SettingDefinitions.RunAnalysis, true);
 
             if (enabled)
             {


### PR DESCRIPTION
Introduce SettingDefinitions for user-configurable analysis options (enable/disable, rules, SQL version). Update SqlAnalyzerDiagnosticsService to use these settings when not in a SQL project. Refactor project context logic and include diagnostic messages in error tags for better feedback in SSMS