### PR TITLE
Update analyzer launch to use dnx; clarify docs

### DIFF
--- a/tools/SqlAnalyzerSsms/Linter/Linting/AnalyzerUtilities.cs
+++ b/tools/SqlAnalyzerSsms/Linter/Linting/AnalyzerUtilities.cs
@@ -133,7 +133,7 @@ internal sealed class AnalyzerUtilities
 
     private static void StartAnalyzerProcess(Process analyzer, AsyncQueue<string> lineQueue, string path, string rules, string sqlVersion)
     {
-        var args = $"-n -i \"{path}\"";
+        var args = $"/c dnx ErikEJ.DacFX.TSQLAnalyzer.Cli --yes -- -n -i \"{path}\"";
 
         if (!string.IsNullOrWhiteSpace(rules))
         {
@@ -148,7 +148,7 @@ internal sealed class AnalyzerUtilities
         analyzer.StartInfo = new ProcessStartInfo()
         {
             FileName = "cmd.exe",
-            Arguments = $"/c tsqlanalyze {args}",
+            Arguments = args,
             RedirectStandardOutput = true,
             UseShellExecute = false,
             CreateNoWindow = true,

--- a/tools/SqlAnalyzerSsms/readme.md
+++ b/tools/SqlAnalyzerSsms/readme.md
@@ -36,7 +36,9 @@ In addition, the extension supports analysis of any SQL script in your editor, w
 
 ### Installation Requirements
 
-- The [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download) is required to run the T-SQL Analyzer CLI tool, which is used by the extension to perform analysis. The SDK is automatically installed with the Database DevOps workload in SSMS.
+- The extension automatically uses the `dnx` command to run the T-SQL Analyzer CLI tool as a NuGet package. No separate installation is required.
+
+- The [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download) is required and is automatically installed with the Database DevOps workload in SSMS.
 
 ## How can I help?
 


### PR DESCRIPTION
Switched analyzer process to use dnx for running the CLI as a NuGet package instead of direct tsqlanalyze invocation. Updated documentation to reflect the new launch method and clarified .NET SDK requirements.