### PR TITLE
Refactor file path handling in SSMS error list integration

### DIFF
--- a/tools/SqlAnalyzerSsms/Linter/ErrorList/DocumentHandler.cs
+++ b/tools/SqlAnalyzerSsms/Linter/ErrorList/DocumentHandler.cs
@@ -16,16 +16,19 @@ namespace SqlAnalyzerSsms.Linter.ErrorList
         private readonly ITextView _textView;
         private readonly SqlLintTableDataSource _tableDataSource;
         private readonly SqlAnalysisCache _analysisCache;
+        private readonly string _filePath;
         private bool _disposed;
 
         public DocumentHandler(
             ITextView textView,
             SqlLintTableDataSource tableDataSource,
-            SqlAnalysisCache analysisCache)
+            SqlAnalysisCache analysisCache,
+            string filePath)
         {
             _textView = textView;
             _tableDataSource = tableDataSource;
             _analysisCache = analysisCache;
+            _filePath = filePath;
 
             // Only listen for analysis results — the tagger owns triggering analysis
             // (on buffer changes, option saves, and initial file open).
@@ -39,14 +42,14 @@ namespace SqlAnalyzerSsms.Linter.ErrorList
                 return;
             }
 
-            var identity = DocumentIdentity.Get(_textView);
+            var documentName = DocumentIdentity.GetDocumentName(_textView);
 
             new InvalidOperationException(
-                $"Identity: filePath='{identity.FilePath}', documentName='{identity.DocumentName}'")
+                $"Identity: filePath='{_filePath}', documentName='{documentName}'")
                 .Log();
 
             // Update error list with new results
-            _tableDataSource?.UpdateErrors(identity.FilePath, identity.DocumentName, e.ProjectName, e.Violations);
+            _tableDataSource?.UpdateErrors(_filePath, documentName, e.ProjectName, e.Violations);
         }
 
         public void Dispose()
@@ -55,8 +58,7 @@ namespace SqlAnalyzerSsms.Linter.ErrorList
             {
                 _disposed = true;
                 _analysisCache.AnalysisUpdated -= OnAnalysisUpdated;
-                var identity = DocumentIdentity.Get(_textView);
-                _tableDataSource?.ClearErrors(identity.FilePath);
+                _tableDataSource?.ClearErrors(_filePath);
             }
         }
     }

--- a/tools/SqlAnalyzerSsms/Linter/ErrorList/DocumentIdentity.cs
+++ b/tools/SqlAnalyzerSsms/Linter/ErrorList/DocumentIdentity.cs
@@ -12,7 +12,7 @@ namespace SqlAnalyzerSsms.Linter.ErrorList
     {
         private const string DefaultDocumentName = "query.sql";
 
-        public static (string FilePath, string DocumentName) Get(ITextView textView)
+        public static string GetDocumentName(ITextView textView)
         {
             string? windowCaption = GetWindowCaption();
             string? virtualDocumentName = GetVirtualDocumentName(windowCaption);
@@ -36,16 +36,7 @@ namespace SqlAnalyzerSsms.Linter.ErrorList
                 documentName = DefaultDocumentName;
             }
 
-            if (string.IsNullOrWhiteSpace(filePath))
-            {
-                filePath = documentName;
-            }
-            else if (useVirtualName)
-            {
-                filePath = virtualDocumentName!;
-            }
-
-            return (filePath, documentName);
+            return documentName;
         }
 
         private static bool IsInTempFolder(string filePath)

--- a/tools/SqlAnalyzerSsms/Linter/ErrorList/SqlDocumentListener.cs
+++ b/tools/SqlAnalyzerSsms/Linter/ErrorList/SqlDocumentListener.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using SqlAnalyzerSsms.Linter.Linting;
@@ -23,10 +24,26 @@ namespace SqlAnalyzerSsms.Linter.ErrorList
 
         public void TextViewCreated(ITextView textView)
         {
+            var filePath = GetFilePath(textView);
+            if (filePath == null)
+            {
+                return;
+            }
+
 #pragma warning disable CA2000 // Dispose objects before losing scope
-            var handler = new DocumentHandler(textView, TableDataSource, AnalysisCache);
+            var handler = new DocumentHandler(textView, TableDataSource, AnalysisCache, filePath);
 #pragma warning restore CA2000 // Dispose objects before losing scope
             textView.Closed += (s, e) => handler.Dispose();
+        }
+
+        private static string? GetFilePath(ITextView textView)
+        {
+            if (textView.TextBuffer.Properties.TryGetProperty(typeof(ITextDocument), out ITextDocument document))
+            {
+                return string.IsNullOrWhiteSpace(document.FilePath) ? null : document.FilePath;
+            }
+
+            return null;
         }
     }
 }

--- a/tools/SqlAnalyzerSsms/Linter/Linting/AnalysisUpdatedEventArgs.cs
+++ b/tools/SqlAnalyzerSsms/Linter/Linting/AnalysisUpdatedEventArgs.cs
@@ -11,7 +11,6 @@ namespace SqlAnalyzerSsms.Linter.Linting
         ITextBuffer buffer,
         ITextSnapshot snapshot,
         IReadOnlyList<SqlAnalyzerDiagnosticInfo> violations,
-        string filePath,
         string projectName) : EventArgs
     {
         public ITextBuffer Buffer { get; } = buffer;
@@ -19,8 +18,6 @@ namespace SqlAnalyzerSsms.Linter.Linting
         public ITextSnapshot Snapshot { get; } = snapshot;
 
         public IReadOnlyList<SqlAnalyzerDiagnosticInfo> Violations { get; } = violations;
-
-        public string FilePath { get; } = filePath;
 
         public string ProjectName { get; } = projectName;
     }

--- a/tools/SqlAnalyzerSsms/Linter/Linting/SqlAnalysisCache.cs
+++ b/tools/SqlAnalyzerSsms/Linter/Linting/SqlAnalysisCache.cs
@@ -128,7 +128,7 @@ namespace SqlAnalyzerSsms.Linter.Linting
 
                 buffer.Properties[_propertyKey] = result;
 
-                AnalysisUpdated?.Invoke(this, new AnalysisUpdatedEventArgs(buffer, snapshot, violations, filePath, projectName));
+                AnalysisUpdated?.Invoke(this, new AnalysisUpdatedEventArgs(buffer, snapshot, violations, projectName));
             }
             catch (OperationCanceledException)
             {

--- a/tools/SqlAnalyzerSsms/Linter/Tagging/SqlLintTagger.cs
+++ b/tools/SqlAnalyzerSsms/Linter/Tagging/SqlLintTagger.cs
@@ -26,7 +26,7 @@ namespace SqlAnalyzerSsms.Linter.Tagging
         private List<LintResult> _currentResults;
         private bool _isDisposed;
 
-public event EventHandler<SnapshotSpanEventArgs>? TagsChanged;
+        public event EventHandler<SnapshotSpanEventArgs>? TagsChanged;
 
         public SqlLintTagger(ITextBuffer buffer, SqlAnalysisCache analysisCache, string sqlVersion, string rules, string projectName)
         {


### PR DESCRIPTION
Refactored error list integration to pass file paths directly from SqlDocumentListener to DocumentHandler, simplifying DocumentIdentity to only provide document names.

Removed file path from AnalysisUpdatedEventArgs and updated all usages. Now only creates DocumentHandler when a file path is available. Includes minor cleanup and event signature corrections.