### PR TITLE
Add "Disable with" to docs, simplify message formatting

### DIFF
--- a/docs/Design/SRD0001.md
+++ b/docs/Design/SRD0001.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0001 |
 | Friendly Name | Missing natural key |
+| Disable with | -SqlServer.Rules.SRD0001 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Table  |

--- a/docs/Design/SRD0002.md
+++ b/docs/Design/SRD0002.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0002 |
 | Friendly Name | Missing primary key |
+| Disable with | -SqlServer.Rules.SRD0002 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Table  |

--- a/docs/Design/SRD0003.md
+++ b/docs/Design/SRD0003.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0003 |
 | Friendly Name | Avoid wide primary keys |
+| Disable with | -SqlServer.Rules.SRD0003 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Primary Key Constraint  |

--- a/docs/Design/SRD0004.md
+++ b/docs/Design/SRD0004.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0004 |
 | Friendly Name | Index on Foreign Key |
+| Disable with | -SqlServer.Rules.SRD0004 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Foreign Key Constraint  |

--- a/docs/Design/SRD0005.md
+++ b/docs/Design/SRD0005.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0005 |
 | Friendly Name | Avoid long CHAR types |
+| Disable with | -SqlServer.Rules.SRD0005 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Table  |

--- a/docs/Design/SRD0006.md
+++ b/docs/Design/SRD0006.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0006 |
 | Friendly Name | Avoid SELECT * |
+| Disable with | -SqlServer.Rules.SRD0006 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0009.md
+++ b/docs/Design/SRD0009.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0009 |
 | Friendly Name | Non-transactional body |
+| Disable with | -SqlServer.Rules.SRD0009 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0011.md
+++ b/docs/Design/SRD0011.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0011 |
 | Friendly Name | Equality Compare With NULL Rule |
+| Disable with | -SqlServer.Rules.SRD0011 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0012.md
+++ b/docs/Design/SRD0012.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0012 |
 | Friendly Name | Unused variable |
+| Disable with | -SqlServer.Rules.SRD0012 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0013.md
+++ b/docs/Design/SRD0013.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0013 |
 | Friendly Name | Expected error handeling |
+| Disable with | -SqlServer.Rules.SRD0013 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0014.md
+++ b/docs/Design/SRD0014.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0014 |
 | Friendly Name | TOP without an ORDER BY |
+| Disable with | -SqlServer.Rules.SRD0014 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0015.md
+++ b/docs/Design/SRD0015.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0015 |
 | Friendly Name | Implicit column list |
+| Disable with | -SqlServer.Rules.SRD0015 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0016.md
+++ b/docs/Design/SRD0016.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0016 |
 | Friendly Name | Unused input parameter |
+| Disable with | -SqlServer.Rules.SRD0016 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0017.md
+++ b/docs/Design/SRD0017.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0017 |
 | Friendly Name | Avoid Deletes Without Where Rule |
+| Disable with | -SqlServer.Rules.SRD0017 |
 | Category | Design |
 | Ignorable |  |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0018.md
+++ b/docs/Design/SRD0018.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0018 |
 | Friendly Name | Unbounded UPDATE |
+| Disable with | -SqlServer.Rules.SRD0018 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0019.md
+++ b/docs/Design/SRD0019.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0019 |
 | Friendly Name | Avoid joining tables with views |
+| Disable with | -SqlServer.Rules.SRD0019 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0020.md
+++ b/docs/Design/SRD0020.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0020 |
 | Friendly Name | Incomplete or missing JOIN predicate |
+| Disable with | -SqlServer.Rules.SRD0020 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0021.md
+++ b/docs/Design/SRD0021.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0021 |
 | Friendly Name | Consider EXISTS Instead Of In Rule |
+| Disable with | -SqlServer.Rules.SRD0021 |
 | Category | Design |
 | Ignorable |  |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0024.md
+++ b/docs/Design/SRD0024.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0024 |
 | Friendly Name | Avoid EXEC or EXECUTE |
+| Disable with | -SqlServer.Rules.SRD0024 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0025.md
+++ b/docs/Design/SRD0025.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0025 |
 | Friendly Name | Avoid ORDER BY with numbers |
+| Disable with | -SqlServer.Rules.SRD0025 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0026.md
+++ b/docs/Design/SRD0026.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0026 |
 | Friendly Name | Unspecified type length |
+| Disable with | -SqlServer.Rules.SRD0026 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0027.md
+++ b/docs/Design/SRD0027.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0027 |
 | Friendly Name | Unspecified precision or scale  |
+| Disable with | -SqlServer.Rules.SRD0027 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0028.md
+++ b/docs/Design/SRD0028.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0028 |
 | Friendly Name | Consider Column Prefix Rule |
+| Disable with | -SqlServer.Rules.SRD0028 |
 | Category | Design |
 | Ignorable |  |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0030.md
+++ b/docs/Design/SRD0030.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0030 |
 | Friendly Name | Avoid Use of HINTS |
+| Disable with | -SqlServer.Rules.SRD0030 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0031.md
+++ b/docs/Design/SRD0031.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0031 |
 | Friendly Name | Avoid using CHARINDEX |
+| Disable with | -SqlServer.Rules.SRD0031 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0032.md
+++ b/docs/Design/SRD0032.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0032 |
 | Friendly Name | Avoid use of OR in where clause |
+| Disable with | -SqlServer.Rules.SRD0032 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0033.md
+++ b/docs/Design/SRD0033.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0033 |
 | Friendly Name | Avoid Cursors |
+| Disable with | -SqlServer.Rules.SRD0033 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0034.md
+++ b/docs/Design/SRD0034.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0034 |
 | Friendly Name | Use of NOLOCK |
+| Disable with | -SqlServer.Rules.SRD0034 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0035.md
+++ b/docs/Design/SRD0035.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0035 |
 | Friendly Name | Forced delay |
+| Disable with | -SqlServer.Rules.SRD0035 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Dml Trigger  |

--- a/docs/Design/SRD0036.md
+++ b/docs/Design/SRD0036.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0036 |
 | Friendly Name | Do not use SET ROWCOUNT |
+| Disable with | -SqlServer.Rules.SRD0036 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0038.md
+++ b/docs/Design/SRD0038.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0038 |
 | Friendly Name | Alias Tables Rule |
+| Disable with | -SqlServer.Rules.SRD0038 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0039.md
+++ b/docs/Design/SRD0039.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0039 |
 | Friendly Name | Object not schema qualified |
+| Disable with | -SqlServer.Rules.SRD0039 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0041.md
+++ b/docs/Design/SRD0041.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0041 |
 | Friendly Name | Avoid SELECT INTO temp or table variables |
+| Disable with | -SqlServer.Rules.SRD0041 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0043.md
+++ b/docs/Design/SRD0043.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0043 |
 | Friendly Name | Possible side-effects implicit cast  |
+| Disable with | -SqlServer.Rules.SRD0043 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0044.md
+++ b/docs/Design/SRD0044.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0044 |
 | Friendly Name | Error handling requires SA permissions |
+| Disable with | -SqlServer.Rules.SRD0044 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0045.md
+++ b/docs/Design/SRD0045.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0045 |
 | Friendly Name | Excessive indexes on table |
+| Disable with | -SqlServer.Rules.SRD0045 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Table  |

--- a/docs/Design/SRD0046.md
+++ b/docs/Design/SRD0046.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0046 |
 | Friendly Name | Use of approximate data type |
+| Disable with | -SqlServer.Rules.SRD0046 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0047.md
+++ b/docs/Design/SRD0047.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0047 |
 | Friendly Name | Ambiguous column name across design |
+| Disable with | -SqlServer.Rules.SRD0047 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Model  |

--- a/docs/Design/SRD0050.md
+++ b/docs/Design/SRD0050.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0050 |
 | Friendly Name | Expression reducible to constaint |
+| Disable with | -SqlServer.Rules.SRD0050 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0051.md
+++ b/docs/Design/SRD0051.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0051 |
 | Friendly Name | Do Not Use Deprecated Types Rule |
+| Disable with | -SqlServer.Rules.SRD0051 |
 | Category | Design |
 | Ignorable |  |
 | Applicable Types | Table  |

--- a/docs/Design/SRD0052.md
+++ b/docs/Design/SRD0052.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0052 |
 | Friendly Name | Duplicate/Overlapping Index |
+| Disable with | -SqlServer.Rules.SRD0052 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Table  |

--- a/docs/Design/SRD0053.md
+++ b/docs/Design/SRD0053.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0053 |
 | Friendly Name | Explicit collation other |
+| Disable with | -SqlServer.Rules.SRD0053 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Table  |

--- a/docs/Design/SRD0055.md
+++ b/docs/Design/SRD0055.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0055 |
 | Friendly Name | Object level option override |
+| Disable with | -SqlServer.Rules.SRD0055 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Dml Trigger  |

--- a/docs/Design/SRD0056.md
+++ b/docs/Design/SRD0056.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0056 |
 | Friendly Name | Unsafe identity retrieval |
+| Disable with | -SqlServer.Rules.SRD0056 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Dml Trigger  |

--- a/docs/Design/SRD0057.md
+++ b/docs/Design/SRD0057.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0057 |
 | Friendly Name | Do Not Mix DML With DDL Rule |
+| Disable with | -SqlServer.Rules.SRD0057 |
 | Category | Design |
 | Ignorable |  |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0058.md
+++ b/docs/Design/SRD0058.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0058 |
 | Friendly Name | Ordinal parameters used |
+| Disable with | -SqlServer.Rules.SRD0058 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0060.md
+++ b/docs/Design/SRD0060.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0060 |
 | Friendly Name | Permission change in stored procedure |
+| Disable with | -SqlServer.Rules.SRD0060 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0061.md
+++ b/docs/Design/SRD0061.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0061 |
 | Friendly Name | Invalid database configured options |
+| Disable with | -SqlServer.Rules.SRD0061 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Model  |

--- a/docs/Design/SRD0062.md
+++ b/docs/Design/SRD0062.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0062 |
 | Friendly Name | Implicit collation |
+| Disable with | -SqlServer.Rules.SRD0062 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0063.md
+++ b/docs/Design/SRD0063.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0063 |
 | Friendly Name | Avoid wrapping SQL in IF statement |
+| Disable with | -SqlServer.Rules.SRD0063 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0064.md
+++ b/docs/Design/SRD0064.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0064 |
 | Friendly Name | Consider Caching Get Date To Variable |
+| Disable with | -SqlServer.Rules.SRD0064 |
 | Category | Design |
 | Ignorable |  |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0065.md
+++ b/docs/Design/SRD0065.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0065 |
 | Friendly Name | Avoid NOT FOR REPLICATION |
+| Disable with | -SqlServer.Rules.SRD0065 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Check Constraint  |

--- a/docs/Design/SRD0066.md
+++ b/docs/Design/SRD0066.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0066 |
 | Friendly Name | BEGIN and END symbols inside conditional statements. |
+| Disable with | -SqlServer.Rules.SRD0066 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0067.md
+++ b/docs/Design/SRD0067.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0067 |
 | Friendly Name | Use capitalized keywords for enhanced readability. |
+| Disable with | -SqlServer.Rules.SRD0067 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0068.md
+++ b/docs/Design/SRD0068.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0068 |
 | Friendly Name | Terminate statements with semicolon. |
+| Disable with | -SqlServer.Rules.SRD0068 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0069.md
+++ b/docs/Design/SRD0069.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0069 |
 | Friendly Name | Xact_Abort On |
+| Disable with | -SqlServer.Rules.SRD0069 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0071.md
+++ b/docs/Design/SRD0071.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0071 |
 | Friendly Name | CASE without ELSE |
+| Disable with | -SqlServer.Rules.SRD0071 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0072.md
+++ b/docs/Design/SRD0072.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0072 |
 | Friendly Name | Variable self-assignment |
+| Disable with | -SqlServer.Rules.SRD0072 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0073.md
+++ b/docs/Design/SRD0073.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0073 |
 | Friendly Name | Repeated NOT operator |
+| Disable with | -SqlServer.Rules.SRD0073 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0074.md
+++ b/docs/Design/SRD0074.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0074 |
 | Friendly Name | Weak hashing algorithm |
+| Disable with | -SqlServer.Rules.SRD0074 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0075.md
+++ b/docs/Design/SRD0075.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0075 |
 | Friendly Name | Hard-coded credentials |
+| Disable with | -SqlServer.Rules.SRD0075 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0076.md
+++ b/docs/Design/SRD0076.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0076 |
 | Friendly Name | Identical expressions on both sides |
+| Disable with | -SqlServer.Rules.SRD0076 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0077.md
+++ b/docs/Design/SRD0077.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0077 |
 | Friendly Name | FETCH variable count mismatch |
+| Disable with | -SqlServer.Rules.SRD0077 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0078.md
+++ b/docs/Design/SRD0078.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0078 |
 | Friendly Name | Single character alias |
+| Disable with | -SqlServer.Rules.SRD0078 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0079.md
+++ b/docs/Design/SRD0079.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0079 |
 | Friendly Name | Single character variable |
+| Disable with | -SqlServer.Rules.SRD0079 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0080.md
+++ b/docs/Design/SRD0080.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0080 |
 | Friendly Name | TOP expression should use parentheses |
+| Disable with | -SqlServer.Rules.SRD0080 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0081.md
+++ b/docs/Design/SRD0081.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0081 |
 | Friendly Name | TOP(100) PERCENT ignored by optimizer |
+| Disable with | -SqlServer.Rules.SRD0081 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0082.md
+++ b/docs/Design/SRD0082.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0082 |
 | Friendly Name | Do not change DATEFORMAT |
+| Disable with | -SqlServer.Rules.SRD0082 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0083.md
+++ b/docs/Design/SRD0083.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0083 |
 | Friendly Name | Avoid changing DATEFIRST |
+| Disable with | -SqlServer.Rules.SRD0083 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0084.md
+++ b/docs/Design/SRD0084.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0084 |
 | Friendly Name | Concat Null Yields Null ON |
+| Disable with | -SqlServer.Rules.SRD0084 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0085.md
+++ b/docs/Design/SRD0085.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0085 |
 | Friendly Name | ANSI_NULLS should be ON |
+| Disable with | -SqlServer.Rules.SRD0085 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Dml Trigger  |

--- a/docs/Design/SRD0086.md
+++ b/docs/Design/SRD0086.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0086 |
 | Friendly Name | ANSI_PADDING should be ON |
+| Disable with | -SqlServer.Rules.SRD0086 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0087.md
+++ b/docs/Design/SRD0087.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0087 |
 | Friendly Name | ANSI_WARNINGS should be ON |
+| Disable with | -SqlServer.Rules.SRD0087 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0088.md
+++ b/docs/Design/SRD0088.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0088 |
 | Friendly Name | NUMERIC_ROUNDABORT should be OFF |
+| Disable with | -SqlServer.Rules.SRD0088 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Dml Trigger  |

--- a/docs/Design/SRD0089.md
+++ b/docs/Design/SRD0089.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0089 |
 | Friendly Name | Quoted identifier on |
+| Disable with | -SqlServer.Rules.SRD0089 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0090.md
+++ b/docs/Design/SRD0090.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0090 |
 | Friendly Name | SET FORCEPLAN should be OFF |
+| Disable with | -SqlServer.Rules.SRD0090 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0091.md
+++ b/docs/Design/SRD0091.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0091 |
 | Friendly Name | Avoid ORDER BY in derived tables for final ordering |
+| Disable with | -SqlServer.Rules.SRD0091 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0092.md
+++ b/docs/Design/SRD0092.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0092 |
 | Friendly Name | Avoid named primary key constraints on temp tables |
+| Disable with | -SqlServer.Rules.SRD0092 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0093.md
+++ b/docs/Design/SRD0093.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0093 |
 | Friendly Name | Do not name default constraints on temporary tables |
+| Disable with | -SqlServer.Rules.SRD0093 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0094.md
+++ b/docs/Design/SRD0094.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0094 |
 | Friendly Name | Avoid named foreign keys on temporary tables |
+| Disable with | -SqlServer.Rules.SRD0094 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0095.md
+++ b/docs/Design/SRD0095.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0095 |
 | Friendly Name | Named check constraints on temp tables |
+| Disable with | -SqlServer.Rules.SRD0095 |
 | Category | Design |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0096.md
+++ b/docs/Design/SRD0096.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0096 |
 | Friendly Name | Potential SQL injection issue |
+| Disable with | -SqlServer.Rules.SRD0096 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Design/SRD0700.md
+++ b/docs/Design/SRD0700.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0700 |
 | Friendly Name | Database PAGE_VERIFY option is not CHECKSUM |
+| Disable with | -SqlServer.Rules.SRD0700 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Model  |

--- a/docs/Design/SRD0701.md
+++ b/docs/Design/SRD0701.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0701 |
 | Friendly Name | Database QUERY_STORE option is not READ_WRITE |
+| Disable with | -SqlServer.Rules.SRD0701 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Model  |

--- a/docs/Design/SRD0703.md
+++ b/docs/Design/SRD0703.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0703 |
 | Friendly Name | Database QUERY_STORE_CAPTURE_MODE option is not AUTO |
+| Disable with | -SqlServer.Rules.SRD0703 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Model  |

--- a/docs/Design/SRD0704.md
+++ b/docs/Design/SRD0704.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0704 |
 | Friendly Name | Database TARGET_RECOVERY_TIME option is not set |
+| Disable with | -SqlServer.Rules.SRD0704 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Model  |

--- a/docs/Design/SRD0705.md
+++ b/docs/Design/SRD0705.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0705 |
 | Friendly Name | Database AUTO_CLOSE option is not OFF |
+| Disable with | -SqlServer.Rules.SRD0705 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Model  |

--- a/docs/Design/SRD0706.md
+++ b/docs/Design/SRD0706.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRD0706 |
 | Friendly Name | Database AUTO_SHRINK option is ON |
+| Disable with | -SqlServer.Rules.SRD0706 |
 | Category | Design |
 | Ignorable | false |
 | Applicable Types | Model  |

--- a/docs/Naming/SRN0001.md
+++ b/docs/Naming/SRN0001.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRN0001 |
 | Friendly Name | UDF with System prefix |
+| Disable with | -SqlServer.Rules.SRN0001 |
 | Category | Naming |
 | Ignorable | true |
 | Applicable Types | Partition Function  |

--- a/docs/Naming/SRN0002.md
+++ b/docs/Naming/SRN0002.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRN0002 |
 | Friendly Name | Procedure name may conflict system name |
+| Disable with | -SqlServer.Rules.SRN0002 |
 | Category | Naming |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Naming/SRN0006.md
+++ b/docs/Naming/SRN0006.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRN0006 |
 | Friendly Name | Use of default schema |
+| Disable with | -SqlServer.Rules.SRN0006 |
 | Category | Naming |
 | Ignorable | false |
 | Applicable Types | Default  |

--- a/docs/Naming/SRN0007.md
+++ b/docs/Naming/SRN0007.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRN0007 |
 | Friendly Name | Name standard |
+| Disable with | -SqlServer.Rules.SRN0007 |
 | Category | Naming |
 | Ignorable | false |
 | Applicable Types | Check Constraint  |

--- a/docs/Performance/SRP0001.md
+++ b/docs/Performance/SRP0001.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0001 |
 | Friendly Name | Nested Views |
+| Disable with | -SqlServer.Rules.SRP0001 |
 | Category | Performance |
 | Ignorable | false |
 | Applicable Types | View  |

--- a/docs/Performance/SRP0002.md
+++ b/docs/Performance/SRP0002.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0002 |
 | Friendly Name | Unanchored string pattern |
+| Disable with | -SqlServer.Rules.SRP0002 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0003.md
+++ b/docs/Performance/SRP0003.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0003 |
 | Friendly Name | Aggregate of unique set |
+| Disable with | -SqlServer.Rules.SRP0003 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0004.md
+++ b/docs/Performance/SRP0004.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0004 |
 | Friendly Name | Noisy trigger |
+| Disable with | -SqlServer.Rules.SRP0004 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Dml Trigger  |

--- a/docs/Performance/SRP0005.md
+++ b/docs/Performance/SRP0005.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0005 |
 | Friendly Name | Noisy trigger |
+| Disable with | -SqlServer.Rules.SRP0005 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Dml Trigger  |

--- a/docs/Performance/SRP0006.md
+++ b/docs/Performance/SRP0006.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0006 |
 | Friendly Name | Use of inequality |
+| Disable with | -SqlServer.Rules.SRP0006 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0007.md
+++ b/docs/Performance/SRP0007.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0007 |
 | Friendly Name | Dangling cursor |
+| Disable with | -SqlServer.Rules.SRP0007 |
 | Category | Performance |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0008.md
+++ b/docs/Performance/SRP0008.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0008 |
 | Friendly Name | Unfreed cursor |
+| Disable with | -SqlServer.Rules.SRP0008 |
 | Category | Performance |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0009.md
+++ b/docs/Performance/SRP0009.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0009 |
 | Friendly Name | Filtering on calculated value |
+| Disable with | -SqlServer.Rules.SRP0009 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0010.md
+++ b/docs/Performance/SRP0010.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0010 |
 | Friendly Name | Function in data modification |
+| Disable with | -SqlServer.Rules.SRP0010 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0011.md
+++ b/docs/Performance/SRP0011.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0011 |
 | Friendly Name | Non-member test in predicate |
+| Disable with | -SqlServer.Rules.SRP0011 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0012.md
+++ b/docs/Performance/SRP0012.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0012 |
 | Friendly Name | Un-indexed membership test |
+| Disable with | -SqlServer.Rules.SRP0012 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0013.md
+++ b/docs/Performance/SRP0013.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0013 |
 | Friendly Name | Existence tested with JOIN |
+| Disable with | -SqlServer.Rules.SRP0013 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0014.md
+++ b/docs/Performance/SRP0014.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0014 |
 | Friendly Name | Table variable in JOIN |
+| Disable with | -SqlServer.Rules.SRP0014 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0015.md
+++ b/docs/Performance/SRP0015.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0015 |
 | Friendly Name | Avoid Column Calculations |
+| Disable with | -SqlServer.Rules.SRP0015 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0016.md
+++ b/docs/Performance/SRP0016.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0016 |
 | Friendly Name | Equality test with mismatched types |
+| Disable with | -SqlServer.Rules.SRP0016 |
 | Category | Performance |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0017.md
+++ b/docs/Performance/SRP0017.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0017 |
 | Friendly Name | Update of Primary key |
+| Disable with | -SqlServer.Rules.SRP0017 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0018.md
+++ b/docs/Performance/SRP0018.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0018 |
 | Friendly Name | High join count |
+| Disable with | -SqlServer.Rules.SRP0018 |
 | Category | Performance |
 | Ignorable | false |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0020.md
+++ b/docs/Performance/SRP0020.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0020 |
 | Friendly Name | Missing Clustered index |
+| Disable with | -SqlServer.Rules.SRP0020 |
 | Category | Performance |
 | Ignorable | false |
 | Applicable Types | Table  |

--- a/docs/Performance/SRP0021.md
+++ b/docs/Performance/SRP0021.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0021 |
 | Friendly Name | Manipulated parameter value |
+| Disable with | -SqlServer.Rules.SRP0021 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0022.md
+++ b/docs/Performance/SRP0022.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0022 |
 | Friendly Name | Procedure level recompile option |
+| Disable with | -SqlServer.Rules.SRP0022 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0023.md
+++ b/docs/Performance/SRP0023.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0023 |
 | Friendly Name | Enumerating for existence check |
+| Disable with | -SqlServer.Rules.SRP0023 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0024.md
+++ b/docs/Performance/SRP0024.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0024 |
 | Friendly Name | Correlated subquery |
+| Disable with | -SqlServer.Rules.SRP0024 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0025.md
+++ b/docs/Performance/SRP0025.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0025 |
 | Friendly Name | SELECT * in EXISTS |
+| Disable with | -SqlServer.Rules.SRP0025 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0026.md
+++ b/docs/Performance/SRP0026.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0026 |
 | Friendly Name | Avoid cross-server joins |
+| Disable with | -SqlServer.Rules.SRP0026 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0027.md
+++ b/docs/Performance/SRP0027.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0027 |
 | Friendly Name | Avoid explicit conversion of columnar data |
+| Disable with | -SqlServer.Rules.SRP0027 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0028.md
+++ b/docs/Performance/SRP0028.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0028 |
 | Friendly Name | Explicit RANGE window frame |
+| Disable with | -SqlServer.Rules.SRP0028 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0029.md
+++ b/docs/Performance/SRP0029.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0029 |
 | Friendly Name | Implicit RANGE window frame |
+| Disable with | -SqlServer.Rules.SRP0029 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/docs/Performance/SRP0030.md
+++ b/docs/Performance/SRP0030.md
@@ -12,6 +12,7 @@
 |----|----|
 | Id | SRP0030 |
 | Friendly Name | Specify FAST_FORWARD for cursors |
+| Disable with | -SqlServer.Rules.SRP0030 |
 | Category | Performance |
 | Ignorable | true |
 | Applicable Types | Procedure  |

--- a/tools/SqlAnalyzerVsix/AnalyzerUtilities.cs
+++ b/tools/SqlAnalyzerVsix/AnalyzerUtilities.cs
@@ -205,17 +205,13 @@ internal sealed class AnalyzerUtilities : IDisposable
             var fullRule = string.IsNullOrWhiteSpace(problem.Rule) ? "unknown" : problem.Rule;
             var errorCode = fullRule;
             var separatorIndex = fullRule.LastIndexOf('.');
-            var rulePrefix = string.Empty;
 
             if (separatorIndex > 0 && separatorIndex < fullRule.Length - 1)
             {
-                rulePrefix = fullRule.Substring(0, separatorIndex);
                 errorCode = fullRule.Substring(separatorIndex + 1);
             }
 
-            var message = string.IsNullOrWhiteSpace(problem.Message)
-                ? fullRule
-                : string.IsNullOrWhiteSpace(rulePrefix) ? problem.Message : rulePrefix + ": " + problem.Message;
+            var message = problem.Message;
 
             Uri? helpLink = null;
             if (!string.IsNullOrWhiteSpace(problem.HelpLink)

--- a/tools/SqlServer.Rules.DocsGenerator/Program.cs
+++ b/tools/SqlServer.Rules.DocsGenerator/Program.cs
@@ -250,6 +250,7 @@ public static class Program
         stringBuilder.AppendLine("|----|----|");
         stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"| Id | {attribute.Id.ToId()} |");
         stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"| Friendly Name | {friendlyName} |");
+        stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"| Disable with | -{attribute.Id} |");
         stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"| Category | {attribute.Category} |");
         stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"| Ignorable | {isIgnorable} |");
         stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"| Applicable Types | {elements.First()}  |");


### PR DESCRIPTION
Add a "Disable with" line to each rule's Markdown documentation, showing the CLI flag to disable the rule. Update the documentation generator to include this line. Simplify AnalyzerUtilities message formatting to always use problem.Message without rule prefix logic.